### PR TITLE
Bump pytest version >=3.6,<3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==3.3.2",
+        "pytest>=3.6,<3.7",
         "pytest-xdist",
         "tox>=2.9.1,<3",
     ],


### PR DESCRIPTION
## What was wrong?

Use the same pytest version setting as py-evm

## How was it fixed?
`"pytest>=3.6,<3.7"`

#### Cute Animal Picture

🐑