### PR TITLE
Fix 18, Add more Tree hash tests to uint, bytes, and bytes_n

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
         "pytest>=3.6,<3.7",
         "pytest-xdist",
         "tox>=2.9.1,<3",
+        "hypothesis==3.69.5",
     ],
     'lint': [
         "flake8==3.4.1",

--- a/ssz/sedes/bytes_n.py
+++ b/ssz/sedes/bytes_n.py
@@ -21,7 +21,7 @@ class BytesN(FixedSizedSedes[BytesOrByteArray, bytes]):
     def serialize_content(self, value: BytesOrByteArray) -> bytes:
         if len(value) != self.length:
             raise SerializationError(
-                f"Can only serialize values of exactly {len(value)} bytes, got"
+                f"Can only serialize values of exactly {self.length} bytes, got"
                 f"{encode_hex(value)} which is {len(value)} bytes."
             )
         return value

--- a/tests/core/tree_hash/test_lists.py
+++ b/tests/core/tree_hash/test_lists.py
@@ -8,8 +8,8 @@ from ssz.sedes import (
     BytesN,
     List,
     bytes32_list,
-    uint32_list,
     bytes_list,
+    uint32_list,
 )
 from ssz.tree_hash.tree_hash import (
     hash_tree_root,
@@ -105,7 +105,7 @@ def test_bytes_n_list_randomized(data, length, sequence_type):
     'items',
     (
         tuple(),
-        (b'\x56', b'\xab'*2, b'\xcd'*3),
+        (b'\x56', b'\xab' * 2, b'\xcd' * 3),
         (b'', b'\x56', ),
     ),
 )

--- a/tests/core/tree_hash/test_lists.py
+++ b/tests/core/tree_hash/test_lists.py
@@ -1,8 +1,15 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
 import pytest
 
 from ssz.sedes import (
+    BytesN,
+    List,
     bytes32_list,
     uint32_list,
+    bytes_list,
 )
 from ssz.tree_hash.tree_hash import (
     hash_tree_root,
@@ -10,17 +17,118 @@ from ssz.tree_hash.tree_hash import (
 
 
 @pytest.mark.parametrize(
-    'items,sedes',
+    'items',
     (
-        # Specify values in Tuple
-        ((123, 456, 789, ), uint32_list),
-        (tuple(), uint32_list),
-        ((b'\x56' * 32, ), bytes32_list),
-        ((b'\x56' * 32, ) * 100, bytes32_list),
-        ((b'\x56' * 32, ) * 101, bytes32_list),
+        (123, 456, 789, ),
+        tuple(),
     ),
 )
-def test_iterables(items, sedes):
-    # Make sure Lists are also tested
-    for value in (items, list(items),):
-        assert len(hash_tree_root(value, sedes)) == 32
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_uint32_list_sanity(items, sequence_type):
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, uint32_list)) == 32
+
+
+@given(items=st.lists(
+    st.integers(
+        min_value=0,
+        max_value=2**32 - 1,
+    )
+)
+)
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_uint32_list_randomized(items, sequence_type):
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, uint32_list)) == 32
+
+
+@pytest.mark.parametrize(
+    'items',
+    (
+        tuple(),
+        (b'\x56' * 32, ),
+        (b'\x56' * 32, ) * 100,
+        (b'\x56' * 32, ) * 101,
+    ),
+)
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_bytes_32_list_sanity(items, sequence_type):
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, bytes32_list)) == 32
+
+
+@given(data=st.data())
+@pytest.mark.parametrize(
+    'length',
+    (32, 48, 96),
+)
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_bytes_n_list_randomized(data, length, sequence_type):
+    sedes = List(BytesN(length))
+    items = data.draw(
+        st.lists(
+            st.binary(
+                min_size=length,
+                max_size=length,
+            )
+        )
+    )
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, sedes)) == 32
+
+
+@pytest.mark.parametrize(
+    'items',
+    (
+        tuple(),
+        (b'\x56', b'\xab'*2, b'\xcd'*3),
+        (b'', b'\x56', ),
+    ),
+)
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_bytes_sedes_list_sanity(items, sequence_type):
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, bytes_list)) == 32
+
+
+@given(items=st.lists(st.binary()))
+@pytest.mark.parametrize(
+    'sequence_type,',
+    (
+        list,
+        tuple,
+    )
+)
+def test_bytes_sedes_list_randomized(items, sequence_type):
+    value = sequence_type(items)
+    assert len(hash_tree_root(value, bytes_list)) == 32

--- a/tests/core/tree_hash/test_single_values.py
+++ b/tests/core/tree_hash/test_single_values.py
@@ -44,7 +44,7 @@ def test_boolean_serialize_values(value, sedes, expected):
     (8, 16, 24, 32, 40, 48, 56, 64, 128, 256),
 )
 def test_unsign_integers_less_than_32_bytes(data, num_bits):
-    uintn = UnsignedInteger(num_bits)
+    uint_n = UnsignedInteger(num_bits)
     value = data.draw(
         st.integers(
             min_value=0,
@@ -52,7 +52,7 @@ def test_unsign_integers_less_than_32_bytes(data, num_bits):
         )
     )
     expected = value.to_bytes(num_bits // 8, 'big').ljust(32, b'\x00')
-    assert hash_tree_root(value, uintn) == expected
+    assert hash_tree_root(value, uint_n) == expected
 
 
 @given(data=st.data())
@@ -61,7 +61,7 @@ def test_unsign_integers_less_than_32_bytes(data, num_bits):
     (384, 512),
 )
 def test_unsign_integers_more_than_32_bytes(data, num_bits):
-    uintn = UnsignedInteger(num_bits)
+    uint_n = UnsignedInteger(num_bits)
     value = data.draw(
         st.integers(
             min_value=0,
@@ -69,7 +69,7 @@ def test_unsign_integers_more_than_32_bytes(data, num_bits):
         )
     )
     expected = hash_eth2(value.to_bytes(num_bits // 8, 'big'))
-    assert hash_tree_root(value, uintn) == expected
+    assert hash_tree_root(value, uint_n) == expected
 
 
 @given(value=st.binary())

--- a/tests/core/tree_hash/test_single_values.py
+++ b/tests/core/tree_hash/test_single_values.py
@@ -4,13 +4,12 @@ from hypothesis import (
 )
 import pytest
 
-from ssz.exceptions import (
-    SerializationError,
-)
 from ssz.sedes import (
     Boolean,
-    boolean,
+    BytesN,
     UnsignedInteger,
+    boolean,
+    bytes_sedes,
 )
 from ssz.tree_hash.hash_eth2 import (
     hash_eth2,
@@ -71,3 +70,24 @@ def test_unsign_integers_more_than_32_bytes(data, num_bits):
     )
     expected = hash_eth2(value.to_bytes(num_bits // 8, 'big'))
     assert hash_tree_root(value, uintn) == expected
+
+
+@given(value=st.binary())
+def test_bytes_sedes(value):
+    assert len(hash_tree_root(value, bytes_sedes)) == 32
+
+
+@given(data=st.data())
+@pytest.mark.parametrize(
+    'length',
+    (32, 48, 96),
+)
+def test_bytes_n(data, length):
+    sedes = BytesN(length)
+    value = data.draw(
+        st.binary(
+            min_size=length,
+            max_size=length,
+        )
+    )
+    assert len(hash_tree_root(value, sedes)) == 32

--- a/tests/core/tree_hash/test_single_values.py
+++ b/tests/core/tree_hash/test_single_values.py
@@ -9,6 +9,7 @@ from ssz.exceptions import (
 )
 from ssz.sedes import (
     Boolean,
+    boolean,
     UnsignedInteger,
 )
 from ssz.tree_hash.hash_eth2 import (
@@ -26,8 +27,15 @@ from ssz.tree_hash.tree_hash import (
         (False, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'),  # noqa
     ),
 )
-def test_boolean_serialize_values(value, expected):
-    sedes = Boolean()
+@pytest.mark.parametrize(
+    'sedes,',
+    (
+        None,
+        boolean,
+        Boolean(),
+    )
+)
+def test_boolean_serialize_values(value, sedes, expected):
     assert hash_tree_root(value, sedes) == expected
 
 

--- a/tests/core/tree_hash/test_single_values.py
+++ b/tests/core/tree_hash/test_single_values.py
@@ -1,9 +1,18 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
 import pytest
 
+from ssz.exceptions import (
+    SerializationError,
+)
 from ssz.sedes import (
     Boolean,
-    uint16,
-    uint512,
+    UnsignedInteger,
+)
+from ssz.tree_hash.hash_eth2 import (
+    hash_eth2,
 )
 from ssz.tree_hash.tree_hash import (
     hash_tree_root,
@@ -22,13 +31,35 @@ def test_boolean_serialize_values(value, expected):
     assert hash_tree_root(value, sedes) == expected
 
 
+@given(data=st.data())
 @pytest.mark.parametrize(
-    'value,sedes',
-    (
-        (0, uint16),
-        (56, uint16),
-        (55665566, uint512),
-    ),
+    'num_bits',
+    (8, 16, 24, 32, 40, 48, 56, 64, 128, 256),
 )
-def test_non_iterables(value, sedes):
-    assert len(hash_tree_root(value, sedes)) == 32
+def test_unsign_integers_less_than_32_bytes(data, num_bits):
+    uintn = UnsignedInteger(num_bits)
+    value = data.draw(
+        st.integers(
+            min_value=0,
+            max_value=2**num_bits - 1,
+        )
+    )
+    expected = value.to_bytes(num_bits // 8, 'big').ljust(32, b'\x00')
+    assert hash_tree_root(value, uintn) == expected
+
+
+@given(data=st.data())
+@pytest.mark.parametrize(
+    'num_bits',
+    (384, 512),
+)
+def test_unsign_integers_more_than_32_bytes(data, num_bits):
+    uintn = UnsignedInteger(num_bits)
+    value = data.draw(
+        st.integers(
+            min_value=0,
+            max_value=2**num_bits - 1,
+        )
+    )
+    expected = hash_eth2(value.to_bytes(num_bits // 8, 'big'))
+    assert hash_tree_root(value, uintn) == expected


### PR DESCRIPTION
## What was wrong?

Issue #18

## How was it fixed?

- add randomized tests to 
  - single value sedes and lists sedes
  - for uint, bytes, and bytes_n types.
- fix an error message

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/tMpa4um.jpg)
