### PR TITLE
Fix 31

### DIFF
--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -54,8 +54,8 @@ class BaseSedes(ABC, Generic[TSerializable, TDeserialized]):
             raise ValueError("Number of bytes to read must not be negative")
         elif start_index + num_bytes > len(data):
             raise DeserializationError(
-                f"Tried to read {num_bytes} bytes from {start_index} but the string is only "
-                f"{len(data)} bytes long"
+                f"Tried to read {num_bytes} bytes starting at index {start_index} but the string "
+                f"is only {len(data)} bytes long"
             )
         else:
             continuation_index = start_index + num_bytes

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -14,6 +14,9 @@ from mypy_extensions import (
     TypedDict,
 )
 
+from ssz.exceptions import (
+    DeserializationError,
+)
 from ssz.sedes.base import (
     BaseSedes,
     LengthPrefixedSedes,
@@ -62,6 +65,10 @@ class Container(LengthPrefixedSedes[TAnyTypedDict, Dict[str, Any]]):
             if next_field_start_index <= field_start_index:
                 raise Exception("Invariant: must always make progress")
             field_start_index = next_field_start_index
+
+        if field_start_index < len(content):
+            extra_bytes = len(content) - field_start_index
+            raise DeserializationError(f"Serialized container ends with {extra_bytes} extra bytes")
 
         if field_start_index > len(content):
             raise Exception("Invariant: must not consume more data than available")

--- a/tests/core/test_serializable.py
+++ b/tests/core/test_serializable.py
@@ -242,12 +242,14 @@ def test_container_deserialize_bad_values(value, sedes):
 def test_empty_fields_container_deserialize():
     with pytest.raises(DeserializationError):
         SSZType5.deserialize(SSZType6.serialize(_type_6))
+    with pytest.raises(DeserializationError):
         SSZType6.deserialize(SSZType5.serialize(_type_5))
 
 
 def test_subset_or_superset_fields_container_deserialize_bad_values():
     with pytest.raises(DeserializationError):
         SSZType6.deserialize(SSZType3.serialize(_type_3))
+    with pytest.raises(DeserializationError):
         SSZType3.deserialize(SSZType6.serialize(_type_6))
 
 


### PR DESCRIPTION
## What was wrong?

Issue #31

## How was it fixed?

Raise an exception in `Container.deserialize_content` if there are extra bytes at the end.

Also, fix the test we already had for this.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/51530032-5684f000-1e3a-11e9-935b-e0aec141a72d.jpeg)