### PR TITLE
hash_tree_root cache

### DIFF
--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -62,7 +62,7 @@ class BaseSedes(ABC, Generic[TSerializable, TDeserialized]):
             return data[start_index:start_index + num_bytes], continuation_index
 
     @abstractmethod
-    def intermediate_tree_hash(self, value: TSerializable) -> bytes:
+    def intermediate_tree_hash(self, value: TSerializable, cache=True) -> bytes:
         pass
 
 
@@ -98,7 +98,7 @@ class FixedSizedSedes(BaseSedes[TSerializable, TDeserialized]):
     #
     # Tree hashing
     #
-    def intermediate_tree_hash(self, value: TSerializable) -> bytes:
+    def intermediate_tree_hash(self, value: TSerializable, cache=True) -> bytes:
         serialized = self.serialize(value)
         if self.length <= 32:
             return serialized

--- a/ssz/sedes/bytes.py
+++ b/ssz/sedes/bytes.py
@@ -22,7 +22,7 @@ class Bytes(LengthPrefixedSedes[BytesOrByteArray, bytes]):
     def deserialize_content(self, content: bytes) -> bytes:
         return content
 
-    def intermediate_tree_hash(self, value: BytesOrByteArray) -> bytes:
+    def intermediate_tree_hash(self, value: BytesOrByteArray, cache=True) -> bytes:
         return hash_eth2(self.serialize(value))
 
 

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -73,9 +73,9 @@ class Container(LengthPrefixedSedes[TAnyTypedDict, Dict[str, Any]]):
         if field_start_index > len(content):
             raise Exception("Invariant: must not consume more data than available")
 
-    def intermediate_tree_hash(self, value: TAnyTypedDict) -> bytes:
+    def intermediate_tree_hash(self, value: TAnyTypedDict, cache=True) -> bytes:
         field_hashes = [
-            field_sedes.intermediate_tree_hash(value[field_name])
+            field_sedes.intermediate_tree_hash(value[field_name], cache=cache)
             for field_name, field_sedes in self.fields
         ]
         return hash_eth2(b"".join(field_hashes))

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -97,8 +97,11 @@ class List(LengthPrefixedSedes[Iterable[T], Tuple[S, ...]]):
         if element_start_index > len(content):
             raise Exception("Invariant: must not consume more data than available")
 
-    def intermediate_tree_hash(self, value: Iterable[T]) -> bytes:
-        element_hashes = [self.element_sedes.intermediate_tree_hash(element) for element in value]
+    def intermediate_tree_hash(self, value: Iterable[T], cache=True) -> bytes:
+        element_hashes = [
+            self.element_sedes.intermediate_tree_hash(element, cache=cache)
+            for element in value
+        ]
         return merkle_hash(element_hashes)
 
 

--- a/ssz/tree_hash.py
+++ b/ssz/tree_hash.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
 )
 
@@ -6,19 +7,21 @@ from eth_typing import (
     Hash32,
 )
 
-from ssz.sedes.base import (
-    BaseSedes,
-)
 from ssz.utils import (
     infer_sedes,
 )
 
+if TYPE_CHECKING:
+    from ssz.sedes.base import (  # noqa: F401
+        BaseSedes,
+    )
 
-def hash_tree_root(value: Any, sedes: BaseSedes=None) -> Hash32:
+
+def hash_tree_root(value: Any, sedes: 'BaseSedes'=None, cache=True) -> Hash32:
     if sedes is None:
         sedes = infer_sedes(value)
 
-    intermediate_tree_hash = sedes.intermediate_tree_hash(value)
+    intermediate_tree_hash = sedes.intermediate_tree_hash(value, cache)
 
     if len(intermediate_tree_hash) < 32:
         return Hash32(intermediate_tree_hash.ljust(32, b'\x00'))


### PR DESCRIPTION
## What was wrong?

#36 part 2: add cache for tree hashing

## How was it fixed?

1. Add cache for `intermediate_tree_hash`.
2. Add a helper property `root` in `BaseSerializable`, we can call `BeaconBlock.root` to get the `hash_tree_root` result.

#### The performance result
Note that our test case is not the latest `BeaconState` on the spec, but it does have a long `validator_registry`.

- For the `2**18` validators case:
    - before caching: `11.3532` sec
    - ~~after caching: `0.4081` sec~~ <-- need to update to some more pratical test cases.
- For the `2**22` validators case (the worst case, 4M validators that Vitalik mentioned recently):
    - before caching: `186.1078` sec
    - ~~after caching: `6.7845` sec~~ ~~ <-- need to update to some more pratical test cases.

The performance of the worst case is still too bad... 🥀

#### Cute Animal Picture

![bottlenose-dolphin-dolphin-tooth-mouth-50720](https://user-images.githubusercontent.com/9263930/52337558-efbf2380-2a42-11e9-9354-80becce17c45.jpeg)
