### PR TITLE
Test Runner Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,3 +76,4 @@ workflows:
       - doctest
       - lint
       - py36
+      - yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,3 @@ workflows:
       - doctest
       - lint
       - py36
-      - yaml

--- a/ssz/sedes/__init__.py
+++ b/ssz/sedes/__init__.py
@@ -51,7 +51,7 @@ from .vector import (  # noqa: F401
 )
 
 sedes_by_name = {
-    "boolean": boolean,
+    "bool": boolean,
 
     "byte": byte,
     "bytes4": bytes4,

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -33,14 +33,16 @@ TAnyTypedDict = TypeVar("TAnyTypedDict", bound=AnyTypedDict)
 class Container(CompositeSedes[TAnyTypedDict, Dict[str, Any]]):
 
     def __init__(self, fields: Sequence[Tuple[str, BaseSedes[Any, Any]]]) -> None:
-        field_names = tuple(field_name for field_name, field_sedes in fields)
-        duplicate_field_names = get_duplicates(field_names)
+        self.fields = fields
+        self.field_names = tuple(field_name for field_name, _ in self.fields)
+        self.field_sedes_objects = tuple(field_sedes for _, field_sedes in self.fields)
+        self.field_name_to_sedes = dict(self.fields)
+
+        duplicate_field_names = get_duplicates(self.field_names)
         if duplicate_field_names:
             raise ValueError(
                 f"The following fields are duplicated {','.join(sorted(duplicate_field_names))}"
             )
-
-        self.fields = fields
 
     #
     # Size

--- a/tests/yaml_tests/test_yaml.py
+++ b/tests/yaml_tests/test_yaml.py
@@ -9,7 +9,7 @@ from ruamel.yaml import (
 )
 from yaml_test_execution import (
     execute_ssz_test_case,
-    execute_tree_hash_test_case
+    execute_tree_hash_test_case,
 )
 
 YAML_BASE_DIR = os.path.abspath(os.path.join(__file__, "../../eth2.0-tests/"))


### PR DESCRIPTION
- Revive and fix the YAML test runner
- ~Enable running tree hash test vectors.~
- (unrelated, but not worthy of its own PR) make field names/sedes easier to access when given a container instance (implemented to simplify the test generator slightly)


#### Cute Animal Picture
![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/55483259-86185b80-5626-11e9-8677-274b2f6b86d5.jpg)