### PR TITLE
Update and pin pytest and pytest-xdist version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest>=3.6,<3.7",
-        "pytest-xdist",
+        "pytest==4.4.0",
+        "pytest-xdist==1.28.0",
         "tox>=2.9.1,<3",
         "hypothesis==3.69.5",
         "ruamel.yaml==0.15.87",


### PR DESCRIPTION
## What was wrong?

Master branch is failing on CI due to an update of `pytest-xdist`.

## How was it fixed?

- Use newest version of pytest and pytest-xdist
- Pin their versions so that this doesn't happen again