### PR TITLE
Serialize to json or yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ extras_require = {
         "pytest-xdist==1.28.0",
         "tox>=2.9.1,<3",
         "hypothesis==3.69.5",
-        "ruamel.yaml==0.15.87",
     ],
     'lint': [
         "flake8==3.4.1",
@@ -51,6 +50,7 @@ setup(
         "eth-utils>=1,<2",
         "eth-hash[pycryptodome]",
         "mypy-extensions>=0.4.1,<1.0.0",
+        "ruamel.yaml==0.15.87",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6, <4',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "eth-utils>=1,<2",
         "eth-hash[pycryptodome]",
         "mypy-extensions>=0.4.1,<1.0.0",
-        "ruamel.yaml==0.15.87",
+        "ruamel.yaml<=0.15",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6, <4',

--- a/ssz/__init__.py
+++ b/ssz/__init__.py
@@ -39,6 +39,12 @@ from .sedes import (  # noqa: F401
     uint128,
     uint256,
 )
+from .tools.text_io import (  # noqa: F401
+    from_json,
+    from_yaml,
+    to_json,
+    to_yaml,
+)
 from .tree_hash import (  # noqa: F401
     hash_tree_root,
 )

--- a/ssz/examples/__init__.py
+++ b/ssz/examples/__init__.py
@@ -1,0 +1,6 @@
+from .state import (  # noqa: F401
+    State,
+    Validator,
+    state,
+    validator,
+)

--- a/ssz/examples/state.py
+++ b/ssz/examples/state.py
@@ -1,0 +1,49 @@
+from ssz.sedes import (
+    List,
+    Serializable,
+    Vector,
+    boolean,
+    bytes32,
+    bytes48,
+    uint64,
+)
+
+SHARDCOUNT = 10
+
+
+class Validator(Serializable):
+    fields = [
+        ('pubkey', bytes48),
+        ('withdrawal_credentials', bytes32),
+        ('exit_epoch', uint64),
+        ('slashed', boolean),
+    ]
+
+
+class Crosslink(Serializable):
+    fields = [
+        ('slot', uint64),
+        ('shard_block_root', bytes32),
+    ]
+
+
+class State(Serializable):
+    fields = [
+        ('validator_registry', List(Validator)),
+        ('current_crosslinks', Vector(Crosslink, SHARDCOUNT))
+    ]
+
+
+validator = Validator(
+    pubkey=b'\x56' * 48,
+    withdrawal_credentials=b'\x56' * 32,
+    exit_epoch=123,
+    slashed=False,
+)
+crosslink = Crosslink(slot=12847, shard_block_root=b'\x67' * 32)
+crosslink_record_stubs = [crosslink for i in range(SHARDCOUNT)]
+
+state = State(
+    validator_registry=tuple(validator for i in range(5)),
+    current_crosslinks=crosslink_record_stubs,
+)

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -3,7 +3,9 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    Any,
     Generic,
+    Sequence,
     Tuple,
     TypeVar,
 )
@@ -91,6 +93,14 @@ class BaseSedes(ABC, Generic[TSerializable, TDeserialized]):
     def hash_tree_root(self, value: TSerializable) -> bytes:
         pass
 
+    @abstractmethod
+    def serialize_text(self, value):
+        pass
+
+    @abstractmethod
+    def deserialize_text(self, content):
+        pass
+
 
 class BasicSedes(BaseSedes[TSerializable, TDeserialized]):
     def __init__(self, size: int):
@@ -175,3 +185,16 @@ class CompositeSedes(BaseSedes[TSerializable, TDeserialized]):
     @abstractmethod
     def deserialize_content(self, content: bytes) -> TDeserialized:
         pass
+
+    def serialize_text(self, value: Sequence[TSerializable]) -> Tuple[Any, ...]:
+        pairs = self._get_item_sedes_pairs(value)
+
+        return tuple(
+            sedes.serialize_text(item)
+            for item, sedes
+            in pairs
+        )
+
+    def deserialize_text(self, content: Sequence[Any]) -> Tuple[TDeserialized, ...]:
+        pairs = self._get_item_sedes_pairs(content)
+        return tuple(sedes.deserialize_text(item) for item, sedes in pairs)

--- a/ssz/sedes/boolean.py
+++ b/ssz/sedes/boolean.py
@@ -33,5 +33,11 @@ class Boolean(BasicSedes[bool, bool]):
                 f"{encode_hex(content)})",
             )
 
+    def serialize_text(self, value: bool) -> bool:
+        return value
+
+    def deserialize_text(self, content: bool) -> bool:
+        return content
+
 
 boolean = Boolean()

--- a/ssz/sedes/byte.py
+++ b/ssz/sedes/byte.py
@@ -1,3 +1,8 @@
+from eth_utils import (
+    decode_hex,
+    encode_hex,
+)
+
 from ssz.sedes.base import (
     BasicSedes,
 )
@@ -12,6 +17,12 @@ class Byte(BasicSedes[bytes, bytes]):
 
     def deserialize_content(self, content: bytes) -> bytes:
         return content
+
+    def serialize_text(self, value: bytes) -> str:
+        return encode_hex(value)
+
+    def deserialize_text(self, content: str) -> bytes:
+        return decode_hex(content)
 
 
 byte = Byte()

--- a/ssz/sedes/byte_list.py
+++ b/ssz/sedes/byte_list.py
@@ -2,6 +2,11 @@ from typing import (
     Union,
 )
 
+from eth_utils import (
+    decode_hex,
+    encode_hex,
+)
+
 from ssz.sedes.base import (
     CompositeSedes,
 )
@@ -30,6 +35,12 @@ class ByteList(CompositeSedes[BytesOrByteArray, bytes]):
         merkle_leaves = pack_bytes(value)
         merkleized = merkleize(merkle_leaves)
         return mix_in_length(merkleized, len(value))
+
+    def serialize_text(self, value: bytes) -> str:
+        return encode_hex(value)
+
+    def deserialize_text(self, content: str) -> bytes:
+        return decode_hex(content)
 
 
 byte_list = ByteList()

--- a/ssz/sedes/byte_vector.py
+++ b/ssz/sedes/byte_vector.py
@@ -2,6 +2,11 @@ from typing import (
     Union,
 )
 
+from eth_utils import (
+    decode_hex,
+    encode_hex,
+)
+
 from ssz.exceptions import (
     SerializationError,
 )
@@ -51,6 +56,12 @@ class ByteVector(CompositeSedes[BytesOrByteArray, bytes]):
     def hash_tree_root(self, value: bytes) -> bytes:
         serialized_value = self.serialize(value)
         return merkleize(pack_bytes(serialized_value))
+
+    def serialize_text(self, value: bytes) -> str:
+        return encode_hex(value)
+
+    def deserialize_text(self, content: str) -> bytes:
+        return decode_hex(content)
 
 
 bytes4 = ByteVector(4)

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -102,3 +102,15 @@ class Container(CompositeSedes[TAnyTypedDict, Dict[str, Any]]):
             for field_name, field_sedes in self.fields
         )
         return merkleize(merkle_leaves)
+
+    def serialize_text(self, value: TAnyTypedDict):
+        return dict(
+            (field_name, field_sedes.serialize_text(value[field_name]))
+            for field_name, field_sedes in self.fields
+        )
+
+    @to_dict
+    def deserialize_text(self, content: TAnyTypedDict)-> Generator[Tuple[str, Any], None, None]:
+        for field_name, field_sedes in self.fields:
+            field_value = field_sedes.deserialize_text(content[field_name])
+            yield field_name, field_value

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -128,5 +128,11 @@ class List(CompositeSedes[Iterable[TSerializable], Tuple[TDeserialized, ...]]):
             length = len(merkle_leaves)
         return mix_in_length(merkleize(merkle_leaves), length)
 
+    def serialize_text(self, value):
+        return tuple(self.element_sedes.serialize_text(element) for element in value)
+
+    def deserialize_text(self, content):
+        return tuple(self.element_sedes.deserialize_text(element) for element in content)
+
 
 empty_list: List[None, None] = List(empty=True)

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -382,6 +382,13 @@ class MetaSerializable(abc.ABCMeta):
     def hash_tree_root(cls: Type[TSerializable], value: TSerializable) -> bytes:
         return cls._meta.container_sedes.hash_tree_root(value)
 
+    def serialize_text(cls, value) -> str:
+        return cls._meta.container_sedes.serialize_text(value)
+
+    def deserialize_text(cls, data) -> Tuple[TSerializable, int]:
+        deserialized_field_dict = cls._meta.container_sedes.deserialize_text(data)
+        return cls(**deserialized_field_dict)
+
 
 # Make any class created with MetaSerializable an instance of BaseSedes
 BaseSedes.register(MetaSerializable)

--- a/ssz/sedes/uint.py
+++ b/ssz/sedes/uint.py
@@ -1,3 +1,8 @@
+from eth_utils import (
+    decode_hex,
+    encode_hex,
+)
+
 from ssz.exceptions import (
     SerializationError,
 )
@@ -29,6 +34,12 @@ class UInt(BasicSedes[int, int]):
 
     def deserialize_content(self, content: bytes) -> int:
         return int.from_bytes(content, "little")
+
+    def serialize_text(self, value: int) -> str:
+        return encode_hex(self.serialize_content(value))
+
+    def deserialize_text(self, content: str) -> int:
+        return self.deserialize_content(decode_hex(content))
 
 
 uint8 = UInt(8)

--- a/ssz/sedes/uint.py
+++ b/ssz/sedes/uint.py
@@ -1,8 +1,3 @@
-from eth_utils import (
-    decode_hex,
-    encode_hex,
-)
-
 from ssz.exceptions import (
     SerializationError,
 )
@@ -36,10 +31,10 @@ class UInt(BasicSedes[int, int]):
         return int.from_bytes(content, "little")
 
     def serialize_text(self, value: int) -> str:
-        return encode_hex(self.serialize_content(value))
+        return value
 
     def deserialize_text(self, content: str) -> int:
-        return self.deserialize_content(decode_hex(content))
+        return content
 
 
 uint8 = UInt(8)

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -108,3 +108,9 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
                 for element in value
             )
             return merkleize(element_tree_hashes)
+
+    def serialize_text(self, value):
+        return tuple(self.element_sedes.serialize_text(element) for element in value)
+
+    def deserialize_text(self, content):
+        return tuple(self.element_sedes.deserialize_text(element) for element in content)

--- a/ssz/tools/__init__.py
+++ b/ssz/tools/__init__.py
@@ -1,0 +1,6 @@
+from .text_io import (  # noqa: F401
+    from_json,
+    from_yaml,
+    to_json,
+    to_yaml,
+)

--- a/ssz/tools/text_io.py
+++ b/ssz/tools/text_io.py
@@ -1,0 +1,55 @@
+import json
+from typing import (
+    Any,
+)
+
+from ruamel.yaml import (
+    YAML,
+)
+from ruamel.yaml.compat import (
+    StringIO,
+)
+
+from ssz.sedes import (
+    Serializable,
+    infer_sedes,
+)
+from ssz.sedes.base import (
+    BaseSedes,
+)
+
+
+def encode_text(value: Serializable):
+    sedes_obj = infer_sedes(value)
+    return sedes_obj.serialize_text(value)
+
+
+def decode_text(content: Any, sedes: BaseSedes) -> Serializable:
+    return sedes.deserialize_text(content)
+
+
+def to_json(value: Serializable) -> str:
+    return json.dumps(encode_text(value), indent=4)
+
+
+def from_json(content: Any, sedes: BaseSedes) -> str:
+    return decode_text(json.loads(content), sedes)
+
+
+def to_yaml(value: Serializable) -> str:
+    class CustomYAML(YAML):
+        def dump(self, data, stream=None, **kw):
+            inefficient = False
+            if stream is None:
+                inefficient = True
+                stream = StringIO()
+            YAML.dump(self, data, stream, **kw)
+            if inefficient:
+                return stream.getvalue()
+    yaml = CustomYAML()
+    return yaml.dump(encode_text(value))
+
+
+def from_yaml(content: Any, sedes: BaseSedes) -> str:
+    yaml = YAML()
+    return decode_text(yaml.load(content), sedes)

--- a/tests/tools/test_text_io.py
+++ b/tests/tools/test_text_io.py
@@ -1,10 +1,10 @@
 import pytest
 
+import ssz
 from ssz.examples import (
     State,
     state,
 )
-import ssz.tools
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_text_io.py
+++ b/tests/tools/test_text_io.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ssz.examples import (
+    State,
+    state,
+)
+import ssz.tools
+
+
+@pytest.mark.parametrize(
+    "export_function, import_function", (
+        (ssz.tools.to_json, ssz.tools.from_json),
+        (ssz.tools.to_yaml, ssz.tools.from_yaml),
+    )
+)
+def test_import_export(tmpdir, export_function, import_function):
+    path = tmpdir / "state.dump"
+    with open(path, "w") as f:
+        f.write(export_function(state))
+    with open(path, "r") as f:
+        read_state = import_function(f.read(), State)
+    assert read_state.validator_registry[0].pubkey == state.validator_registry[0].pubkey
+    assert read_state.validator_registry[0].exit_epoch == state.validator_registry[0].exit_epoch


### PR DESCRIPTION
## What was wrong?

A random idea that makes parsing/dumping ssz object easier.

```python
>>> from ssz.examples import state, State
>>> import ssz.tools
>>> yaml_dump = ssz.tools.to_yaml(state)
>>> print(yaml_dump)
validator_registry:
- pubkey: '0x565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656'
  withdrawal_credentials: '0x5656565656565656565656565656565656565656565656565656565656565656'
  exit_epoch: 123
  slashed: false
- pubkey: '0x565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656'
  withdrawal_credentials: '0x5656565656565656565656565656565656565656565656565656565656565656'
  exit_epoch: 123
  slashed: false
- pubkey: '0x565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656'
  withdrawal_credentials: '0x5656565656565656565656565656565656565656565656565656565656565656'
  exit_epoch: 123
  slashed: false
- pubkey: '0x565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656'
  withdrawal_credentials: '0x5656565656565656565656565656565656565656565656565656565656565656'
  exit_epoch: 123
  slashed: false
- pubkey: '0x565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656565656'
  withdrawal_credentials: '0x5656565656565656565656565656565656565656565656565656565656565656'
  exit_epoch: 123
  slashed: false
current_crosslinks:
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'
- slot: 12847
  shard_block_root: '0x6767676767676767676767676767676767676767676767676767676767676767'

>>> ssz.tools.from_yaml(yaml_dump, State)
<ssz.examples.state.State object at 0x1106479b0>
```

## How was it fixed?

- Add serialize text and deserialize text to all sedes classes.
- bytes and ints are hex encoded 

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/56727744-ddbc6980-6783-11e9-929b-2eb768af9816.png)

