### PR TITLE
Fix `BaseSerializable.__eq__` bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
     'test': [
         "pytest==4.4.0",
         "pytest-xdist==1.28.0",
+        "pytest-watch>=4.1.0,<5",
         "tox>=2.9.1,<3",
         "hypothesis==3.69.5",
         "ruamel.yaml==0.15.87",
@@ -23,7 +24,6 @@ extras_require = {
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",
-        "pytest-watch>=4.1.0,<5",
         "wheel",
         "twine",
         "ipython",

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -132,7 +132,7 @@ class BaseSerializable(collections.Sequence):
         return len(self._meta.fields)
 
     def __eq__(self, other):
-        return isinstance(other, BaseSerializable) and hash(self) == hash(other)
+        return self.__class__ == other.__class__ and hash(self) == hash(other)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -132,7 +132,7 @@ class BaseSerializable(collections.Sequence):
         return len(self._meta.fields)
 
     def __eq__(self, other):
-        return isinstance(other, Serializable) and hash(self) == hash(other)
+        return isinstance(other, BaseSerializable) and hash(self) == hash(other)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -132,7 +132,7 @@ class BaseSerializable(collections.Sequence):
         return len(self._meta.fields)
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ and hash(self) == hash(other)
+        return self.__class__ is other.__class__ and hash(self) == hash(other)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tests/misc/test_serializable.py
+++ b/tests/misc/test_serializable.py
@@ -137,8 +137,8 @@ def test_equality():
     assert test_a1 == test_a1
     assert test_a2 == test_a1
     assert test_a3 != test_a1
-    assert test_b1 == test_a1
-    assert test_c1 == test_a1
+    assert test_b1 != test_a1
+    assert test_c1 != test_a1
     assert test_c2 != test_a1
 
 

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -58,3 +58,19 @@ def test_signing_root():
     signed = Signed(123, b"\xaa", b"\x00")
     unsigned = Unsigned(123, b"\xaa")
     assert signed.signing_root == unsigned.root
+
+
+def test_eq():
+    class Signed(ssz.SignedSerializable):
+        fields = (
+            ("field1", uint8),
+            ("field2", byte_list),
+            ("signature", byte_list),
+        )
+
+    signed_a = Signed(123, b"\xaa", b"\x00")
+    signed_b = signed_a.copy()
+    assert signed_a == signed_b
+
+    signed_b = signed_b.copy(field1=456)
+    assert signed_a != signed_b

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -60,17 +60,33 @@ def test_signing_root():
     assert signed.signing_root == unsigned.root
 
 
-def test_eq():
-    class Signed(ssz.SignedSerializable):
+def test_equality():
+    class SigningFoo(ssz.SignedSerializable):
         fields = (
             ("field1", uint8),
             ("field2", byte_list),
             ("signature", byte_list),
         )
 
-    signed_a = Signed(123, b"\xaa", b"\x00")
+    signed_a = SigningFoo(123, b"\xaa", b"\x00")
     signed_b = signed_a.copy()
     assert signed_a == signed_b
+    assert signed_a is not signed_b
 
     signed_b = signed_b.copy(field1=456)
     assert signed_a != signed_b
+
+    # Serializable and SignedSerializable
+    class Foo(ssz.Serializable):
+        fields = (
+            ("field1", uint8),
+            ("field2", byte_list),
+            ("signature", byte_list),
+        )
+
+    foo = Foo(
+        signed_a.field1,
+        signed_a.field2,
+        signed_a.signature,
+    )
+    assert foo == signed_a

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -89,4 +89,4 @@ def test_equality():
         signed_a.field2,
         signed_a.signature,
     )
-    assert foo == signed_a
+    assert foo != signed_a


### PR DESCRIPTION
## What was wrong?

Fix #62 `BaseSerializable.__eq__` bug

## How was it fixed?

1. Move `pytest-watch` to test dep (so I can test with trinity)
2. Check `isinstance(other, BaseSerializable)` instead of `isinstance(other, Serializable)`
3. Add a test for equality

#### Cute Animal Picture

![easter-2197043_640](https://user-images.githubusercontent.com/9263930/56784571-b321ed80-6823-11e9-89fc-fcdc93eff85b.jpg)
