### PR TITLE
hash_tree_root cache

### DIFF
--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -73,7 +73,7 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
     @to_tuple
     def deserialize_content(self, content: bytes) -> Generator[TDeserializedElement, None, None]:
         element_start_index = 0
-        for element_index in range(self.length):
+        for _ in range(self.length):
             element, next_element_start_index = self.element_sedes.deserialize_segment(
                 content,
                 element_start_index,

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -68,12 +68,12 @@ def test_equality():
             ("signature", byte_list),
         )
 
-    signed_a = SigningFoo(123, b"\xaa", b"\x00")
+    signed_a = SigningFoo(12, b"\xaa", b"\x00")
     signed_b = signed_a.copy()
     assert signed_a == signed_b
     assert signed_a is not signed_b
 
-    signed_b = signed_b.copy(field1=456)
+    signed_b = signed_b.copy(field1=34)
     assert signed_a != signed_b
 
     # Serializable and SignedSerializable


### PR DESCRIPTION
## What was wrong?

Fix #67 

## How was it fixed?

1. Add `root_cache` and remove `hash_cache`.
2. Use `self.root == other.root` in `__eq__`.

#### Cute Animal Picture
![bird-691816_640](https://user-images.githubusercontent.com/9263930/57007263-df6dad80-6c19-11e9-9642-b5ff5451709d.jpg)

