### PR TITLE
Add `__hash__` cache back

### DIFF
--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -146,7 +146,9 @@ class BaseSerializable(collections.Sequence):
     _hash_cache = None
 
     def __hash__(self):
-        return hash(self.__class__) * int.from_bytes(self.root, "little")
+        if self._hash_cache is None:
+            self._hash_cache = hash(self.__class__) * int.from_bytes(self.root, "little")
+        return self._hash_cache
 
     def copy(self, *args, **kwargs):
         missing_overrides = set(


### PR DESCRIPTION
## What was wrong?
Was removed in #68, but now I think it's still good to cache it.

## How was it fixed?

Use `_hash_cache`.

Summary of approach.

#### Cute Animal Picture

🦎 