### PR TITLE
Allows a more flexible relationship when comparing classes for `__eq__`

### DIFF
--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -132,7 +132,12 @@ class BaseSerializable(collections.Sequence):
         return len(self._meta.fields)
 
     def __eq__(self, other):
-        return self.__class__ is other.__class__ and self.root == other.root
+        satisfies_class_relationship = (
+            issubclass(self.__class__, other.__class__) or
+            issubclass(other.__class__, self.__class__)
+        )
+        same_root = self.root == other.root
+        return satisfies_class_relationship and same_root
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -136,8 +136,11 @@ class BaseSerializable(collections.Sequence):
             issubclass(self.__class__, other.__class__) or
             issubclass(other.__class__, self.__class__)
         )
-        same_root = self.root == other.root
-        return satisfies_class_relationship and same_root
+
+        if not satisfies_class_relationship:
+            return False
+        else:
+            return self.root == other.root
 
     def __getstate__(self):
         state = self.__dict__.copy()


### PR DESCRIPTION
Namely, one is a subclass of the other

Following up on @jannikluhn's idea to make class equality more flexible

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%3Fid%3DOIP.gKsFsiCM7dRySM1w5_VXwgHaE8%26pid%3DApi&f=1)
