### PR TITLE
fix list deserialization

### DIFF
--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -12,7 +12,6 @@ from eth_utils import (
 )
 from eth_utils.toolz import (
     cons,
-    partition,
     sliding_window,
 )
 
@@ -104,7 +103,8 @@ class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
                     f"element size. data length: {len(data)}  element size: "
                     f"{element_size}"
                 )
-            for segment in partition(element_size, data):
+            for start_idx in range(0, len(data), element_size):
+                segment = data[start_idx: start_idx + element_size]
                 yield self.element_sedes.deserialize(segment)
         else:
             stream_zero_loc = stream.tell()


### PR DESCRIPTION
partition manually, to have bytes instead of tuples as BytesIO input

## What was wrong?

`partition` returns a series of tuples. Tuples are not accepted by BytesIO

## How was it fixed?

Manually slice the input. Credits to @pipermerriam for confirming the problem and suggesting a fix.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://data.whicdn.com/images/316178783/large.jpg)
