### PR TITLE
[POC] Implement fields as descriptors

### DIFF
--- a/ssz/constants.py
+++ b/ssz/constants.py
@@ -9,6 +9,3 @@ SIGNATURE_FIELD_NAME = "signature"
 
 # number of bytes for a serialized offset
 OFFSET_SIZE = 4
-
-
-FIELDS_META_ATTR = "fields"

--- a/ssz/fields.py
+++ b/ssz/fields.py
@@ -1,0 +1,124 @@
+from typing import (
+    Any,
+    Sequence,
+    Tuple,
+)
+
+from ssz import sedes
+from ssz.sedes.serializable import (
+    Field,
+)
+
+
+#
+# int
+#
+class IntField(Field):
+    def __get__(self, instance, owner) -> int:
+        return super().__get__(instance, owner)
+
+    def __set__(self, instance, value: int) -> None:
+        super().__set__(instance, value)
+
+
+class UInt8(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+class UInt16(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+class UInt32(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+class UInt64(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+class UInt128(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+class UInt256(IntField):
+    def __init__(self):
+        super().__init__(sedes.uint8)
+
+
+#
+# bytes
+#
+class BytesField(Field):
+    def __get__(self, instance, owner) -> bytes:
+        return super().__get__(instance, owner)
+
+    def __set__(self, instance, value: bytes) -> None:
+        super().__set__(instance, value)
+
+
+class ByteList(BytesField):
+    def __init__(self):
+        super().__init__(sedes.byte_list)
+
+
+class Bytes4(BytesField):
+    def __init__(self):
+        super().__init__(sedes.bytes4)
+
+
+class Bytes32(BytesField):
+    def __init__(self):
+        super().__init__(sedes.bytes32)
+
+
+class Bytes48(BytesField):
+    def __init__(self):
+        super().__init__(sedes.bytes48)
+
+
+class Bytes96(BytesField):
+    def __init__(self):
+        super().__init__(sedes.bytes96)
+
+
+#
+# bool
+#
+class BoolField(Field):
+    def __get__(self, instance, owner) -> bool:
+        return super().__get__(instance, owner)
+
+    def __set__(self, instance, value: bool) -> None:
+        super().__set__(instance, value)
+
+
+class Boolean(BoolField):
+    def __init__(self):
+        super().__init__(sedes.boolean)
+
+
+#
+# Sequences
+#
+class SequenceField(Field):
+    def __get__(self, instance, owner) -> Tuple[Any, ...]:
+        return super().__get__(instance, owner)
+
+    def __set__(self, instance, value: Sequence[Any]) -> None:
+        super().__set__(instance, value)
+
+
+class Vector(SequenceField):
+    def __init__(self, element_sedes, length):
+        super().__init__(sedes.Vector(element_sedes, length))
+
+
+class List(SequenceField):
+    def __init__(self, element_sedes):
+        super().__init__(sedes.List(element_sedes))

--- a/ssz/sedes/signed_serializable.py
+++ b/ssz/sedes/signed_serializable.py
@@ -16,17 +16,16 @@ from ssz.sedes.container import (
 )
 from ssz.sedes.serializable import (
     BaseSerializable,
+    Field,
     MetaSerializable,
 )
 
 
 class SignedMeta(NamedTuple):
     has_fields: bool
-    fields: Optional[Tuple[Tuple[str, BaseSedes]]]
+    fields: Optional[Tuple[Field]]
     container_sedes: Optional[Container]
     signed_container_sedes: Optional[Container]
-    field_names: Optional[Tuple[str, ...]]
-    field_attrs: Optional[Tuple[str, ...]]
 
 
 class MetaSignedSerializable(MetaSerializable):
@@ -36,10 +35,10 @@ class MetaSignedSerializable(MetaSerializable):
         if cls._meta.has_fields:
             if len(cls._meta.fields) < 2:
                 raise TypeError(f"Signed serializables need to have at least two fields")
-            if cls._meta.field_names[-1] != SIGNATURE_FIELD_NAME:
+            if cls._meta.fields[-1].name != SIGNATURE_FIELD_NAME:
                 raise TypeError(
                     f"Last field of signed serializable must be {SIGNATURE_FIELD_NAME}, but is "
-                    f"{cls._meta.field_names[-1]}"
+                    f"{cls._meta.fields[-1].name}"
                 )
 
             signed_container_sedes = Container(cls._meta.container_sedes.field_sedes[:-1])
@@ -51,8 +50,6 @@ class MetaSignedSerializable(MetaSerializable):
             fields=cls._meta.fields,
             container_sedes=cls._meta.container_sedes,
             signed_container_sedes=signed_container_sedes,
-            field_names=cls._meta.field_names,
-            field_attrs=cls._meta.field_attrs,
         )
         cls._meta = meta
 

--- a/tests/misc/test_serializable.py
+++ b/tests/misc/test_serializable.py
@@ -1,25 +1,17 @@
 import pytest
 
 import ssz
-from ssz.sedes import (
-    uint8,
+from ssz.fields import (
+    UInt8,
 )
-
-
-def test_duplicate_fields():
-    with pytest.raises(TypeError):
-        class Test(ssz.Serializable):
-            fields = (
-                ("field1", uint8),
-                ("field1", uint8),
-            )
+from ssz.sedes.serializable import (
+    Field,
+)
 
 
 def test_field_immutability():
     class Test(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-        )
+        field1 = UInt8()
 
     test = Test(4)
     with pytest.raises(AttributeError):
@@ -40,10 +32,8 @@ def test_field_immutability():
 )
 def test_initialization_with_invalid_arguments(args, kwargs):
     class Test(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     with pytest.raises(TypeError):
         Test(*args, **kwargs)
@@ -59,10 +49,8 @@ def test_initialization_with_invalid_arguments(args, kwargs):
 )
 def test_initialization_with_valid_arguments(args, kwargs):
     class Test(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     test = Test(*args, **kwargs)
     assert test.field1 == 1
@@ -71,10 +59,8 @@ def test_initialization_with_valid_arguments(args, kwargs):
 
 def test_copy():
     class Test(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     original = Test(1, 2)
     copy = original.copy()
@@ -86,16 +72,12 @@ def test_copy():
 
 def test_copy_nested():
     class Inner(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     class Outer(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", Inner),
-        )
+        field1 = UInt8()
+        field2 = Field(Inner)
 
     original = Outer(1, Inner(2, 3))
     copy = original.copy()
@@ -110,22 +92,16 @@ def test_copy_nested():
 
 def test_equality():
     class TestA(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     class TestB(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     class TestC(ssz.Serializable):
-        fields = (
-            ("field2", uint8),
-            ("field1", uint8),
-        )
+        field2 = UInt8()
+        field1 = UInt8()
 
     test_a1 = TestA(1, 2)
     test_a2 = TestA(1, 2)
@@ -144,10 +120,8 @@ def test_equality():
 
 def test_root():
     class Test(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", uint8),
-        )
+        field1 = UInt8()
+        field2 = UInt8()
 
     test = Test(1, 2)
     assert test.root == ssz.hash_tree_root(test, Test)

--- a/tests/misc/test_serializable_inheritance.py
+++ b/tests/misc/test_serializable_inheritance.py
@@ -1,8 +1,8 @@
 import pytest
 
 import ssz
-from ssz.sedes import (
-    uint8,
+from ssz.fields import (
+    UInt8,
 )
 
 
@@ -37,7 +37,8 @@ def create_inheritance_structure(structure):
         if class_defines_fields:
             field_names = (f"field{index}",)
             namespace = {
-                "fields": tuple((field_name, uint8) for field_name in field_names)
+                field_name: UInt8()
+                for field_name in field_names
             }
         else:
             parent_field_names = tuple(

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -1,59 +1,43 @@
 import pytest
 
 import ssz
-from ssz.sedes import (
-    byte_list,
-    uint8,
+from ssz.fields import (
+    ByteList,
+    UInt8,
 )
 
 
 def test_field_number_check():
     with pytest.raises(TypeError):
-        class TestA(ssz.SignedSerializable):
-            fields = ()
-
-    with pytest.raises(TypeError):
         class TestB(ssz.SignedSerializable):
-            fields = (
-                ("signature", byte_list),
-            )
+            signature = ByteList()
 
     class TestC(ssz.SignedSerializable):
-        fields = (
-            ("field1", uint8),
-            ("signature", byte_list),
-        )
+        field1 = UInt8()
+        signature = ByteList()
 
 
 def test_field_name_check():
     with pytest.raises(TypeError):
         class TestA(ssz.SignedSerializable):
-            fields = (
-                ("field1", uint8),
-                ("field2", byte_list),
-            )
+            field1 = UInt8()
+            field2 = ByteList()
 
     with pytest.raises(TypeError):
         class TestB(ssz.SignedSerializable):
-            fields = (
-                ("signature", uint8),
-                ("field1", byte_list),
-            )
+            signature = UInt8()
+            field1 = ByteList()
 
 
 def test_signing_root():
     class Signed(ssz.SignedSerializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", byte_list),
-            ("signature", byte_list),
-        )
+        field1 = UInt8()
+        field2 = ByteList()
+        signature = ByteList()
 
     class Unsigned(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", byte_list),
-        )
+        field1 = UInt8()
+        field2 = ByteList()
 
     signed = Signed(123, b"\xaa", b"\x00")
     unsigned = Unsigned(123, b"\xaa")
@@ -62,11 +46,9 @@ def test_signing_root():
 
 def test_equality():
     class SigningFoo(ssz.SignedSerializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", byte_list),
-            ("signature", byte_list),
-        )
+        field1 = UInt8()
+        field2 = ByteList()
+        signature = ByteList()
 
     signed_a = SigningFoo(12, b"\xaa", b"\x00")
     signed_b = signed_a.copy()
@@ -78,11 +60,9 @@ def test_equality():
 
     # Serializable and SignedSerializable
     class Foo(ssz.Serializable):
-        fields = (
-            ("field1", uint8),
-            ("field2", byte_list),
-            ("signature", byte_list),
-        )
+        field1 = UInt8()
+        field2 = ByteList()
+        signature = ByteList()
 
     foo = Foo(
         signed_a.field1,


### PR DESCRIPTION
POC of how an alternative fields implementation using Python descriptors instead of a list of fields. This provides a nicer interface and type hints, at least in some cases.