### PR TITLE
Rename `hash_tree_root` function to `get_hash_tree_root` and `root` property to `hash_tree_root`

### DIFF
--- a/scripts/benchmark/tree_hash.py
+++ b/scripts/benchmark/tree_hash.py
@@ -100,7 +100,7 @@ def prepare_byte_vector_benchmark():
 
     def benchmark():
         for data_item in data:
-            ssz.hash_tree_root(data_item, byte_vector)
+            ssz.get_hash_tree_root(data_item, byte_vector)
 
     return benchmark
 
@@ -117,7 +117,7 @@ def prepare_byte_list_benchmark():
 
     def benchmark():
         for data_item in data:
-            ssz.hash_tree_root(data_item, byte_list)
+            ssz.get_hash_tree_root(data_item, byte_list)
 
     return benchmark
 
@@ -126,7 +126,7 @@ def prepare_state_benchmark():
     state = make_state(2**15)
 
     def benchmark():
-        ssz.hash_tree_root(state)
+        ssz.get_hash_tree_root(state)
 
     return benchmark
 

--- a/ssz/__init__.py
+++ b/ssz/__init__.py
@@ -42,5 +42,5 @@ from .sedes import (  # noqa: F401
     uint256,
 )
 from .tree_hash import (  # noqa: F401
-    hash_tree_root,
+    get_hash_tree_root,
 )

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -66,7 +66,7 @@ class BaseSedes(ABC, Generic[TSerializable, TDeserialized]):
     # Tree hashing
     #
     @abstractmethod
-    def hash_tree_root(self, value: TSerializable) -> bytes:
+    def get_hash_tree_root(self, value: TSerializable) -> bytes:
         pass
 
 
@@ -91,7 +91,7 @@ class BasicSedes(BaseSedes[TSerializable, TDeserialized]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: TSerializable) -> bytes:
+    def get_hash_tree_root(self, value: TSerializable) -> bytes:
         serialized_value = self.serialize(value)
         return merkleize(pack((serialized_value,)))
 

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -72,7 +72,7 @@ class Bitlist(BaseCompositeSedes[BytesOrByteArray, bytes]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: Sequence[bool]) -> bytes:
+    def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
         return mix_in_length(merkleize(pack_bits(value)), len(value))
 
 

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -63,5 +63,5 @@ class Bitvector(BaseCompositeSedes[BytesOrByteArray, bytes]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: Sequence[bool]) -> bytes:
+    def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
         return merkleize(pack_bits(value))

--- a/ssz/sedes/byte_list.py
+++ b/ssz/sedes/byte_list.py
@@ -27,7 +27,7 @@ class ByteList(BaseCompositeSedes[BytesOrByteArray, bytes]):
     def deserialize(self, data: bytes) -> bytes:
         return data
 
-    def hash_tree_root(self, value: bytes) -> bytes:
+    def get_hash_tree_root(self, value: bytes) -> bytes:
         merkle_leaves = pack_bytes(value)
         merkleized = merkleize(merkle_leaves)
         return mix_in_length(merkleized, len(value))

--- a/ssz/sedes/byte_vector.py
+++ b/ssz/sedes/byte_vector.py
@@ -55,7 +55,7 @@ class ByteVector(BaseCompositeSedes[BytesOrByteArray, bytes]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: bytes) -> bytes:
+    def get_hash_tree_root(self, value: bytes) -> bytes:
         serialized_value = self.serialize(value)
         return merkleize(pack_bytes(serialized_value))
 

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -155,9 +155,9 @@ class Container(CompositeSedes[Sequence[Any], Tuple[Any, ...]]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: Tuple[Any, ...]) -> bytes:
+    def get_hash_tree_root(self, value: Tuple[Any, ...]) -> bytes:
         merkle_leaves = tuple(
-            sedes.hash_tree_root(element)
+            sedes.get_hash_tree_root(element)
             for element, sedes in zip(value, self.field_sedes)
         )
         return merkleize(merkle_leaves)

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -61,7 +61,7 @@ class EmptyList(BaseCompositeSedes[Sequence[TSerializable], Tuple[TSerializable,
             raise DeserializationError("Cannot deserialize non-empty bytes using `EmptyList` sedes")
         return tuple()
 
-    def hash_tree_root(self, value: Sequence[TSerializable]) -> bytes:
+    def get_hash_tree_root(self, value: Sequence[TSerializable]) -> bytes:
         if len(value):
             raise ValueError("Cannot compute tree hash for non-empty value using `EmptyList` sedes")
         return EMPTY_LIST_HASH_TREE_ROOT
@@ -152,7 +152,7 @@ class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: Iterable[TSerializable]) -> bytes:
+    def get_hash_tree_root(self, value: Iterable[TSerializable]) -> bytes:
         if isinstance(self.element_sedes, BasicSedes):
             serialized_items = tuple(
                 self.element_sedes.serialize(element)
@@ -161,7 +161,7 @@ class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
             merkle_leaves = pack(serialized_items)
         else:
             merkle_leaves = tuple(
-                self.element_sedes.hash_tree_root(element)
+                self.element_sedes.get_hash_tree_root(element)
                 for element in value
             )
         base_size = self.max_length * get_item_length(self.element_sedes)

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -143,7 +143,7 @@ class BaseSerializable(collections.Sequence):
         if not satisfies_class_relationship:
             return False
         else:
-            return self.root == other.root
+            return self.hash_tree_root == other.hash_tree_root
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -158,7 +158,7 @@ class BaseSerializable(collections.Sequence):
 
     def __hash__(self):
         if self._hash_cache is None:
-            self._hash_cache = hash(self.__class__) * int.from_bytes(self.root, "little")
+            self._hash_cache = hash(self.__class__) * int.from_bytes(self.hash_tree_root, "little")
         return self._hash_cache
 
     def copy(self, *args, **kwargs):
@@ -185,13 +185,13 @@ class BaseSerializable(collections.Sequence):
     def __deepcopy__(self, *args):
         return self.copy()
 
-    _root_cache = None
+    _hash_tree_root_cache = None
 
     @property
-    def root(self):
-        if self._root_cache is None:
-            self._root_cache = ssz.hash_tree_root(self)
-        return self._root_cache
+    def hash_tree_root(self):
+        if self._hash_tree_root_cache is None:
+            self._hash_tree_root_cache = ssz.get_hash_tree_root(self)
+        return self._hash_tree_root_cache
 
 
 def make_immutable(value):
@@ -370,8 +370,8 @@ class MetaSerializable(abc.ABCMeta):
         deserialized_field_dict = dict(zip(cls._meta.field_names, deserialized_fields))
         return cls(**deserialized_field_dict)
 
-    def hash_tree_root(cls: Type[TSerializable], value: TSerializable) -> bytes:
-        return cls._meta.container_sedes.hash_tree_root(value)
+    def get_hash_tree_root(cls: Type[TSerializable], value: TSerializable) -> bytes:
+        return cls._meta.container_sedes.get_hash_tree_root(value)
 
     @property
     def is_fixed_sized(cls):

--- a/ssz/sedes/signed_serializable.py
+++ b/ssz/sedes/signed_serializable.py
@@ -65,4 +65,4 @@ BaseSedes.register(MetaSignedSerializable)
 class SignedSerializable(BaseSerializable, metaclass=MetaSignedSerializable):
     @property
     def signing_root(self):
-        return ssz.hash_tree_root(self, self._meta.signed_container_sedes)
+        return ssz.get_hash_tree_root(self, self._meta.signed_container_sedes)

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -101,7 +101,7 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
     #
     # Tree hashing
     #
-    def hash_tree_root(self, value: Sequence[Any]) -> bytes:
+    def get_hash_tree_root(self, value: Sequence[Any]) -> bytes:
         if isinstance(self.element_sedes, BasicSedes):
             serialized_elements = tuple(
                 self.element_sedes.serialize(element)
@@ -110,7 +110,7 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
             return merkleize(pack(serialized_elements))
         else:
             element_tree_hashes = tuple(
-                self.element_sedes.hash_tree_root(element)
+                self.element_sedes.get_hash_tree_root(element)
                 for element in value
             )
             return merkleize(element_tree_hashes)

--- a/ssz/tree_hash.py
+++ b/ssz/tree_hash.py
@@ -14,8 +14,8 @@ from ssz.sedes.base import (
 )
 
 
-def hash_tree_root(value: Any, sedes: BaseSedes = None) -> Hash32:
+def get_hash_tree_root(value: Any, sedes: BaseSedes = None) -> Hash32:
     if sedes is None:
         sedes = infer_sedes(value)
 
-    return sedes.hash_tree_root(value)
+    return sedes.get_hash_tree_root(value)

--- a/tests/misc/test_serializable.py
+++ b/tests/misc/test_serializable.py
@@ -150,4 +150,4 @@ def test_root():
         )
 
     test = Test(1, 2)
-    assert test.root == ssz.hash_tree_root(test, Test)
+    assert test.hash_tree_root == ssz.get_hash_tree_root(test, Test)

--- a/tests/misc/test_signed_serializable.py
+++ b/tests/misc/test_signed_serializable.py
@@ -57,7 +57,7 @@ def test_signing_root():
 
     signed = Signed(123, b"\xaa", b"\x00")
     unsigned = Unsigned(123, b"\xaa")
-    assert signed.signing_root == unsigned.root
+    assert signed.signing_root == unsigned.hash_tree_root
 
 
 def test_equality():

--- a/tests/tree_hash/test_aliases_tree_hash.py
+++ b/tests/tree_hash/test_aliases_tree_hash.py
@@ -20,8 +20,8 @@ from ssz.sedes import (
     tuple(bytes([byte_value]) for byte_value in range(256)),
 )
 def test_byte(value):
-    expected = ssz.hash_tree_root(int.from_bytes(value, byteorder="little"), uint8)
-    assert ssz.hash_tree_root(value, byte) == expected
+    expected = ssz.get_hash_tree_root(int.from_bytes(value, byteorder="little"), uint8)
+    assert ssz.get_hash_tree_root(value, byte) == expected
 
 
 @given(st.binary())
@@ -29,13 +29,13 @@ def test_byte_list(value):
     byte_sequence = tuple(bytes([byte_value]) for byte_value in value)
     max_length = ssz.utils.get_next_power_of_two(len(value))
     assert (
-        ssz.hash_tree_root(value, byte_list) ==
-        ssz.hash_tree_root(byte_sequence, List(byte, max_length))
+        ssz.get_hash_tree_root(value, byte_list) ==
+        ssz.get_hash_tree_root(byte_sequence, List(byte, max_length))
     )
 
 
 @given(st.binary())
 def test_byte_vector(value):
     byte_sequence = tuple(bytes([byte_value]) for byte_value in value)
-    expected_vector_root = ssz.hash_tree_root(byte_sequence, Vector(byte, len(value)))
-    assert ssz.hash_tree_root(value, ByteVector(len(value))) == expected_vector_root
+    expected_vector_root = ssz.get_hash_tree_root(byte_sequence, Vector(byte, len(value)))
+    assert ssz.get_hash_tree_root(value, ByteVector(len(value))) == expected_vector_root

--- a/tests/tree_hash/test_basic_sedes_trie_hash.py
+++ b/tests/tree_hash/test_basic_sedes_trie_hash.py
@@ -33,10 +33,10 @@ def uint_and_value_strategy(draw):
     ),
 )
 def test_boolean(value, expected):
-    assert ssz.hash_tree_root(value, boolean) == expected
+    assert ssz.get_hash_tree_root(value, boolean) == expected
 
 
 @given(uint_and_value_strategy())
 def test_uint(uint_and_value):
     uint, value = uint_and_value
-    assert ssz.hash_tree_root(value, uint) == ssz.encode(value, uint).ljust(CHUNK_SIZE, b"\x00")
+    assert ssz.get_hash_tree_root(value, uint) == ssz.encode(value, uint).ljust(CHUNK_SIZE, b"\x00")

--- a/tests/tree_hash/test_composite_tree_hash.py
+++ b/tests/tree_hash/test_composite_tree_hash.py
@@ -54,7 +54,7 @@ E_BYTES = b"\xee" * 16
 def test_vector_of_basics(serialized_uints128, result):
     sedes = Vector(uint128, len(serialized_uints128))
     int_values = tuple(ssz.decode(value, uint128) for value in serialized_uints128)
-    assert ssz.hash_tree_root(int_values, sedes) == result
+    assert ssz.get_hash_tree_root(int_values, sedes) == result
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_vector_of_basics(serialized_uints128, result):
 def test_list_of_basic(serialized_uints128, max_length, result):
     # item_length = 128 / 8 = 16
     int_values = tuple(ssz.decode(value, uint128) for value in serialized_uints128)
-    assert ssz.hash_tree_root(int_values, List(uint128, max_length)) == result
+    assert ssz.get_hash_tree_root(int_values, List(uint128, max_length)) == result
 
 
 @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ def test_list_of_basic(serialized_uints128, max_length, result):
 )
 def test_vector_of_composite(bytes16_vector, result):
     sedes = Vector(ByteVector(16), len(bytes16_vector))
-    assert ssz.hash_tree_root(bytes16_vector, sedes) == result
+    assert ssz.get_hash_tree_root(bytes16_vector, sedes) == result
 
 
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ def test_vector_of_composite(bytes16_vector, result):
 def test_list_of_composite(bytes16_list, max_length, result):
     # item_length = 32
     sedes = List(bytes16, max_length)
-    assert ssz.hash_tree_root(bytes16_list, sedes) == result
+    assert ssz.get_hash_tree_root(bytes16_list, sedes) == result
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ def test_list_of_composite(bytes16_list, max_length, result):
 )
 def test_container(bytes16_fields, result):
     sedes = Container(tuple(itertools.repeat(bytes16, len(bytes16_fields))))
-    assert ssz.hash_tree_root(bytes16_fields, sedes) == result
+    assert ssz.get_hash_tree_root(bytes16_fields, sedes) == result
 
 
 @pytest.mark.parametrize(
@@ -172,7 +172,7 @@ def test_container(bytes16_fields, result):
 )
 def test_bitvector(size, value, result):
     foo = Bitvector(size)
-    assert ssz.hash_tree_root(value, foo) == result
+    assert ssz.get_hash_tree_root(value, foo) == result
 
 
 @pytest.mark.parametrize(
@@ -186,4 +186,4 @@ def test_bitvector(size, value, result):
 )
 def test_bitlist(size, value, result):
     foo = Bitlist(size)
-    assert ssz.hash_tree_root(value, foo) == result
+    assert ssz.get_hash_tree_root(value, foo) == result

--- a/tests/yaml_tests/yaml_test_execution.py
+++ b/tests/yaml_tests/yaml_test_execution.py
@@ -94,7 +94,7 @@ def execute_tree_hash_test_case(test_case):
     sedes = parse_type_definition(test_case["type"])
     value = from_formatted_dict(test_case["value"], sedes, CustomCodec)
     expected_root = decode_hex(test_case["root"])
-    calculated_root = ssz.hash_tree_root(value, sedes)
+    calculated_root = ssz.get_hash_tree_root(value, sedes)
     assert calculated_root == expected_root
 
 


### PR DESCRIPTION
## What was wrong?

Fix #79 

## How was it fixed?

- Rename `root` property to `hash_tree_root` for conflict No.1.
- And then found out we need to rename `hash_tree_root` function to `get_hash_tree_root` for conflict No.2.

#### Cute Animal Picture

🐘