### PR TITLE
Sync v0.8.1

### DIFF
--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -73,7 +73,8 @@ class Bitlist(BaseCompositeSedes[BytesOrByteArray, bytes]):
     # Tree hashing
     #
     def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
-        return mix_in_length(merkleize(pack_bits(value)), len(value))
+        chunk_count = (self.max_bit_count + 255) // 256
+        return mix_in_length(merkleize(pack_bits(value), pad_for=chunk_count), len(value))
 
 
 def get_bitlist_len(x: int) -> int:

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -74,7 +74,7 @@ class Bitlist(BaseCompositeSedes[BytesOrByteArray, bytes]):
     #
     def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
         chunk_count = (self.max_bit_count + 255) // 256
-        return mix_in_length(merkleize(pack_bits(value), pad_for=chunk_count), len(value))
+        return mix_in_length(merkleize(pack_bits(value), limit=chunk_count), len(value))
 
 
 def get_bitlist_len(x: int) -> int:

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -65,4 +65,4 @@ class Bitvector(BaseCompositeSedes[BytesOrByteArray, bytes]):
     #
     def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
         chunk_count = (self.bit_count + 255) // 256
-        return merkleize(pack_bits(value), pad_for=chunk_count)
+        return merkleize(pack_bits(value), limit=chunk_count)

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -64,4 +64,5 @@ class Bitvector(BaseCompositeSedes[BytesOrByteArray, bytes]):
     # Tree hashing
     #
     def get_hash_tree_root(self, value: Sequence[bool]) -> bytes:
-        return merkleize(pack_bits(value))
+        chunk_count = (self.bit_count + 255) // 256
+        return merkleize(pack_bits(value), pad_for=chunk_count)

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -166,4 +166,4 @@ class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
             )
         base_size = self.max_length * get_item_length(self.element_sedes)
         chunk_count = (base_size + CHUNK_SIZE - 1) // CHUNK_SIZE
-        return mix_in_length(merkleize(merkle_leaves, pad_for=chunk_count), len(value))
+        return mix_in_length(merkleize(merkle_leaves, limit=chunk_count), len(value))

--- a/ssz/utils.py
+++ b/ssz/utils.py
@@ -132,10 +132,17 @@ def hash_layer(child_layer: Sequence[bytes]) -> Tuple[Hash32, ...]:
     return parent_layer
 
 
-def merkleize(chunks: Sequence[Hash32], pad_for=1) -> Hash32:
+def merkleize(chunks: Sequence[Hash32], limit: int=None) -> Hash32:
     chunk_len = len(chunks)
+
+    if limit is None:
+        limit = chunk_len
+
+    if limit == 0:
+        return ZERO_HASHES[0]
+
     chunk_depth = max(chunk_len - 1, 0).bit_length()
-    max_depth = max(chunk_depth, (pad_for - 1).bit_length())
+    max_depth = max(chunk_depth, (limit - 1).bit_length())
     if max_depth > len(ZERO_HASHES):
         raise ValueError(f"The number of layers is greater than {len(ZERO_HASHES)}")
 

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -73,17 +73,17 @@ def test_merkleize(chunks, root):
     assert merkleize(chunks) == root
 
 
-@pytest.mark.parametrize(("pad_for", "success"), (
+@pytest.mark.parametrize(("limit", "success"), (
     (2**MAX_ZERO_HASHES_LAYER, True),
     (2**MAX_ZERO_HASHES_LAYER + 1, False),
 ))
-def test_merkleize_edge_case(pad_for, success):
+def test_merkleize_edge_case(limit, success):
     chunks = (A_CHUNK,)
     if success:
-        merkleize(chunks, pad_for=pad_for)
+        merkleize(chunks, limit=limit)
     else:
         with pytest.raises(ValueError):
-            merkleize(chunks, pad_for=pad_for)
+            merkleize(chunks, limit=limit)
 
 
 @pytest.mark.parametrize(("root", "length", "result"), (


### PR DESCRIPTION
## What was wrong?

Sync with spec ethereum/eth2.0-specs#1292

## How was it fixed?
1. Update `def merkleize(chunks: Sequence[Hash32], limit: int=None) -> Hash32`
2. Fix Bits `hash_tree_root` - will need to set `limit` parameter
3. Rename `pad_for` to `limit`

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/9263930/61657436-7b78f380-acf5-11e9-9fca-227276c7c7b9.png)
