### PR TITLE
[Turbo] Rework `BaseSerializable.copy` and `BaseSerializable.__deepcopy__`

### DIFF
--- a/ssz/constants.py
+++ b/ssz/constants.py
@@ -28,3 +28,5 @@ ZERO_HASHES = tuple(
         iterate(lambda child: hash_eth2(child + child), ZERO_BYTES32)
     )
 )
+
+BASE_TYPES = (int, bytes, bool)

--- a/ssz/utils.py
+++ b/ssz/utils.py
@@ -1,6 +1,7 @@
 import collections
 from typing import (
     IO,
+    Any,
     Sequence,
     Tuple,
 )
@@ -13,6 +14,7 @@ from eth_utils.toolz import (
 )
 
 from ssz.constants import (
+    BASE_TYPES,
     CHUNK_SIZE,
     EMPTY_CHUNK,
     OFFSET_SIZE,
@@ -194,3 +196,13 @@ def get_serialized_bytearray(value: Sequence[bool], bit_count: int, extra_byte: 
     for i in range(bit_count):
         as_bytearray[i // 8] |= value[i] << (i % 8)
     return as_bytearray
+
+
+def is_immutable_field_value(value: Any) -> bool:
+    return (
+        type(value) in BASE_TYPES or
+        (
+            isinstance(value, tuple) and
+            (len(value) == 0 or is_immutable_field_value(value[0]))
+        )
+    )


### PR DESCRIPTION
## What was wrong?

Previously on https://github.com/ethereum/trinity/pull/848: `deepcopy` operation is the bottleneck.

## How was it fixed?
1. Rework `copy`:
    - Only need to deep copy if the field is mutable. 
2. Customize `deepcopy`:
    - deepcopy the `self.__dict__.items()` and generate a new object.

### Performance
`247.03 seconds` -> `101.59 seconds` improvement for `test_demo.py`.

### New profile

![](https://svgshare.com/i/EWN.svg)

Note: If this approach is accepted, `pyrlp` could be improved too. It's about 3.5x better for `block.copy()` operation.

#### Cute Animal Picture

![cute-animal-pictures-animals-eating-watermelon-010-640x400](https://user-images.githubusercontent.com/9263930/62854684-9f42be80-bd22-11e9-8de7-fe44186581b2.jpg)
