### PR TITLE
Refactor `merkleize`

### DIFF
--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -41,6 +41,7 @@ from ssz.typing import (
 from ssz.utils import (
     encode_offset,
     merkleize,
+    merkleize_with_cache,
     pack,
 )
 
@@ -71,11 +72,11 @@ class BasicSedes(BaseSedes[TSerializable, TDeserialized]):
                                       value: TSerializable,
                                       cache: CacheObj) -> Tuple[Hash32, CacheObj]:
         serialized_value = self.serialize(value)
-        root, cache = merkleize(
+        return merkleize_with_cache(
             pack((serialized_value,)),
             cache=cache,
         )
-        return root, cache
+        
 
     def chunk_count(self) -> int:
         return 1

--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -76,7 +76,6 @@ class BasicSedes(BaseSedes[TSerializable, TDeserialized]):
             pack((serialized_value,)),
             cache=cache,
         )
-        
 
     def chunk_count(self) -> int:
         return 1

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -24,6 +24,7 @@ from ssz.typing import (
 from ssz.utils import (
     get_serialized_bytearray,
     merkleize,
+    merkleize_with_cache,
     mix_in_length,
     pack_bits,
 )
@@ -84,10 +85,10 @@ class Bitlist(BasicBytesSedes[BytesOrByteArray, bytes]):
     def get_hash_tree_root_and_leaves(self,
                                       value: Sequence[bool],
                                       cache: CacheObj) -> Tuple[Hash32, CacheObj]:
-        root, cache = merkleize(
+        root, cache = merkleize_with_cache(
             pack_bits(value),
-            limit=self.chunk_count(),
             cache=cache,
+            limit=self.chunk_count(),
         )
         return mix_in_length(root, len(value)), cache
 

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -24,6 +24,7 @@ from ssz.typing import (
 from ssz.utils import (
     get_serialized_bytearray,
     merkleize,
+    merkleize_with_cache,
     pack_bits,
 )
 
@@ -78,12 +79,11 @@ class Bitvector(BasicBytesSedes[BytesOrByteArray, bytes]):
                                       value: Sequence[bool],
                                       cache: CacheObj) -> Tuple[Hash32, CacheObj]:
         chunk_count = (self.bit_count + 255) // 256
-        root, cache = merkleize(
+        return merkleize_with_cache(
             pack_bits(value),
-            limit=chunk_count,
             cache=cache,
+            limit=chunk_count,
         )
-        return root, cache
 
     def chunk_count(self) -> int:
         return (self.bit_count + 255) // 256

--- a/ssz/sedes/byte_vector.py
+++ b/ssz/sedes/byte_vector.py
@@ -19,6 +19,7 @@ from ssz.typing import (
 )
 from ssz.utils import (
     merkleize,
+    merkleize_with_cache,
     pack_bytes,
 )
 
@@ -71,11 +72,10 @@ class ByteVector(BasicBytesSedes[BytesOrByteArray, bytes]):
                                       value: bytes,
                                       cache: CacheObj) -> Tuple[Hash32, CacheObj]:
         serialized_value = self.serialize(value)
-        root, cache = merkleize(
+        return merkleize_with_cache(
             pack_bytes(serialized_value),
             cache=cache,
         )
-        return root, cache
 
     def chunk_count(self) -> int:
         return self.length * self.size

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -46,6 +46,7 @@ from ssz.typing import (
 )
 from ssz.utils import (
     merkleize,
+    merkleize_with_cache,
     mix_in_length,
     pack,
     read_exact,
@@ -208,10 +209,10 @@ class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
             else:
                 merkle_leaves = get_merkle_leaves_without_cache(value, self.element_sedes)
 
-        merkleize_result, cache = merkleize(
+        merkleize_result, cache = merkleize_with_cache(
             merkle_leaves,
-            limit=self.chunk_count(),
             cache=cache,
+            limit=self.chunk_count(),
         )
         return mix_in_length(merkleize_result, len(value)), cache
 

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -42,6 +42,7 @@ from ssz.typing import (
 )
 from ssz.utils import (
     merkleize,
+    merkleize_with_cache,
     pack,
     read_exact,
     s_decode_offset,
@@ -152,12 +153,11 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
             else:
                 merkle_leaves = get_merkle_leaves_without_cache(value, self.element_sedes)
 
-        merkleize_result, cache = merkleize(
+        return merkleize_with_cache(
             merkle_leaves,
-            limit=self.chunk_count(),
             cache=cache,
+            limit=self.chunk_count(),
         )
-        return merkleize_result, cache
 
     def chunk_count(self) -> int:
         if isinstance(self.element_sedes, BasicSedes):

--- a/ssz/utils.py
+++ b/ssz/utils.py
@@ -142,7 +142,7 @@ def hash_layer(child_layer: Sequence[bytes]) -> Tuple[Hash32, ...]:
     return parent_layer
 
 
-def get_lengths(chunks: Sequence[Hash32], limit: int, chunk_len: int):
+def _get_lengths(chunks: Sequence[Hash32], limit: int, chunk_len: int) -> Tuple[int, int]:
     chunk_depth = max(chunk_len - 1, 0).bit_length()
     max_depth = max(chunk_depth, (limit - 1).bit_length())
     if max_depth > len(ZERO_HASHES):
@@ -151,11 +151,11 @@ def get_lengths(chunks: Sequence[Hash32], limit: int, chunk_len: int):
     return chunk_depth, max_depth
 
 
-def get_temp_merklized_result(chunks: Sequence[Hash32],
-                              chunk_len: int,
-                              chunk_depth: int,
-                              max_depth: int,
-                              cache: CacheObj) -> Tuple[Sequence[Hash32], CacheObj]:
+def _get_temp_merklized_result(chunks: Sequence[Hash32],
+                               chunk_len: int,
+                               chunk_depth: int,
+                               max_depth: int,
+                               cache: CacheObj) -> Tuple[Sequence[Hash32], CacheObj]:
     temp_list = [None for _ in range(max_depth + 1)]
 
     def merge(leaf: bytes, leaf_index: int) -> None:
@@ -197,12 +197,12 @@ def merkleize_with_cache(chunks: Sequence[Hash32],
     chunk_len = len(chunks)
     if limit is None:
         limit = chunk_len
-    chunk_depth, max_depth = get_lengths(chunks, limit, chunk_len)
+    chunk_depth, max_depth = _get_lengths(chunks, limit, chunk_len)
 
     if limit == 0:
         return ZERO_HASHES[0], cache
 
-    temp_list, cache = get_temp_merklized_result(
+    temp_list, cache = _get_temp_merklized_result(
         chunks=chunks,
         chunk_len=chunk_len,
         chunk_depth=chunk_depth,

--- a/ssz/utils.py
+++ b/ssz/utils.py
@@ -142,7 +142,7 @@ def hash_layer(child_layer: Sequence[bytes]) -> Tuple[Hash32, ...]:
     return parent_layer
 
 
-def _get_lengths(chunks: Sequence[Hash32], limit: int, chunk_len: int) -> Tuple[int, int]:
+def _get_chunk_and_max_depth(chunks: Sequence[Hash32], limit: int, chunk_len: int) -> Tuple[int, int]:
     chunk_depth = max(chunk_len - 1, 0).bit_length()
     max_depth = max(chunk_depth, (limit - 1).bit_length())
     if max_depth > len(ZERO_HASHES):
@@ -197,7 +197,11 @@ def merkleize_with_cache(chunks: Sequence[Hash32],
     chunk_len = len(chunks)
     if limit is None:
         limit = chunk_len
-    chunk_depth, max_depth = _get_lengths(chunks, limit, chunk_len)
+    chunk_depth, max_depth = _get_chunk_and_max_depth(
+        chunks,
+        limit,
+        chunk_len,
+    )
 
     if limit == 0:
         return ZERO_HASHES[0], cache
@@ -225,7 +229,7 @@ def merkleize_with_cache(chunks: Sequence[Hash32],
 
 
 def merkleize(chunks: Sequence[Hash32], limit: int=None) -> Hash32:
-    root, _ = merkleize_with_cache(chunks, dict(), limit)
+    root, _ = merkleize_with_cache(chunks, {}, limit)
     return root
 
 


### PR DESCRIPTION
## What was wrong?

`merkleize(chunks, limit, cache)` was supporting both `cache is None` and `cache is not None` cases, that made it too messy.

## How was it fixed?

Rafactor and separate it into `merkleize_with_cache(chunks: Sequence[Hash32], cache: CacheObj, limit: int=None) -> Tuple[Hash32, CacheObj]` and `merkleize(chunks: Sequence[Hash32], limit: int=None) -> Hash32` functions.

Summary of approach.

#### Cute Animal Picture

![cute-animal-pictures-animals-eating-watermelon-001](https://user-images.githubusercontent.com/9263930/63582695-21a56b00-c5cc-11e9-891f-b3bcf49e87af.jpg)
