### PR TITLE
Rework serialize caches

### DIFF
--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -1,24 +1,14 @@
 import functools
 from typing import (
     Any,
-    Iterable,
-)
-
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    to_tuple,
 )
 
 from ssz.sedes.base import (
     TSedes,
 )
-from ssz.typing import (
-    CacheObj,
-)
 
 
+# @functools.lru_cache(maxsize=2**12)
 def get_key(sedes: TSedes, value: Any) -> str:
     key = _get_key(sedes, value).hex()
     sedes_name = type(sedes).__name__
@@ -35,29 +25,3 @@ def get_key(sedes: TSedes, value: Any) -> str:
 @functools.lru_cache(maxsize=2**12)
 def _get_key(sedes: TSedes, value: Any) -> bytes:
     return sedes.serialize(value)
-
-
-@to_tuple
-def get_merkle_leaves_without_cache(value: Any, element_sedes: TSedes) -> Iterable[Hash32]:
-    for element in value:
-        yield element_sedes.get_hash_tree_root(element)
-
-
-@to_tuple
-def get_merkle_leaves_with_cache(value: Any,
-                                 element_sedes: TSedes,
-                                 cache: CacheObj) -> Iterable[Hash32]:
-    """
-    NOTE: cache is mutable
-    """
-    for element in value:
-        key = element_sedes.get_key(element)
-        if key not in cache:
-            root, cache = (
-                element_sedes.get_hash_tree_root_and_leaves(
-                    element,
-                    cache,
-                )
-            )
-            cache[key] = root
-        yield cache[key]

--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -8,7 +8,6 @@ from ssz.sedes.base import (
 )
 
 
-# @functools.lru_cache(maxsize=2**12)
 def get_key(sedes: TSedes, value: Any) -> str:
     key = _get_key(sedes, value).hex()
     sedes_name = type(sedes).__name__
@@ -16,10 +15,7 @@ def get_key(sedes: TSedes, value: Any) -> str:
         return sedes_name + key
     else:
         # If the serialized result is empty, use sedes name as the key
-        if hasattr(sedes, 'element_sedes'):
-            return sedes_name + str(sedes.max_length)
-        else:
-            return sedes_name
+        return sedes_name
 
 
 @functools.lru_cache(maxsize=2**12)

--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -26,7 +26,10 @@ def get_key(sedes: TSedes, value: Any) -> str:
         return sedes_name + key
     else:
         # If the serialized result is empty, use sedes name as the key
-        return sedes_name
+        if hasattr(sedes, 'element_sedes'):
+            return sedes_name + str(sedes.max_length)
+        else:
+            return sedes_name
 
 
 @functools.lru_cache(maxsize=2**12)

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -5,6 +5,7 @@ from abc import (
 from typing import (
     Any,
     Generic,
+    Sequence,
     Tuple,
 )
 
@@ -76,8 +77,12 @@ class BaseCompositeSedes(BaseSedes[TSerializable, TDeserialized]):
     def get_key(self, value: Any) -> bytes:
         ...
 
+    @abstractmethod
+    def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
+        ...
 
-class BaseByteSedes(BaseSedes[TSerializable, TDeserialized]):
+
+class BaseBytesSedes(BaseSedes[TSerializable, TDeserialized]):
     @abstractmethod
     def get_key(self, value: Any) -> bytes:
         ...

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -2,6 +2,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+import collections
 from typing import (
     Any,
     Generic,
@@ -80,3 +81,7 @@ class BaseCompositeSedes(BaseSedes[TSerializable, TDeserialized]):
             value: Sequence[TSerializable],
             pairs: Optional[Tuple[Tuple[TSerializable, TSedes], ...]]=None) -> int:
         ...
+
+
+class BaseSerializable(collections.Sequence):
+    ...

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -5,6 +5,7 @@ from abc import (
 from typing import (
     Any,
     Generic,
+    Optional,
     Sequence,
     Tuple,
 )
@@ -74,5 +75,8 @@ TSedes = BaseSedes[Any, Any]
 
 class BaseCompositeSedes(BaseSedes[TSerializable, TDeserialized]):
     @abstractmethod
-    def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
+    def get_fixed_size_section_length(
+            self,
+            value: Sequence[TSerializable],
+            pairs: Optional[Tuple[Tuple[TSerializable, TSedes], ...]]=None) -> int:
         ...

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -74,15 +74,5 @@ TSedes = BaseSedes[Any, Any]
 
 class BaseCompositeSedes(BaseSedes[TSerializable, TDeserialized]):
     @abstractmethod
-    def get_key(self, value: Any) -> bytes:
-        ...
-
-    @abstractmethod
     def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
-        ...
-
-
-class BaseBytesSedes(BaseSedes[TSerializable, TDeserialized]):
-    @abstractmethod
-    def get_key(self, value: Any) -> bytes:
         ...

--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -29,7 +29,6 @@ from ssz.exceptions import (
     DeserializationError,
 )
 from ssz.sedes.base import (
-    BaseBytesSedes,
     BaseCompositeSedes,
     BaseSedes,
     TSedes,
@@ -171,6 +170,6 @@ class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
         return get_key(self, value)
 
 
-class BasicBytesSedes(BaseBytesSedes[TSerializable, TDeserialized]):
+class BasicBytesSedes(BaseSedes[TSerializable, TDeserialized]):
     def get_key(self, value: Any) -> bytes:
         return get_key(self, value)

--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -7,6 +7,7 @@ from typing import (
     IO,
     Any,
     Iterable,
+    Optional,
     Sequence,
     Tuple,
 )
@@ -99,8 +100,12 @@ class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
                               ) -> Tuple[Tuple[TSerializable, TSedes], ...]:
         ...
 
-    def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
-        pairs = self._get_item_sedes_pairs(value)
+    def get_fixed_size_section_length(
+            self,
+            value: Sequence[TSerializable],
+            pairs: Optional[Tuple[Tuple[TSerializable, TSedes], ...]]=None) -> int:
+        if pairs is None:
+            pairs = self._get_item_sedes_pairs(value)
         element_sedes = tuple(sedes for element, sedes in pairs)
         return _compute_fixed_size_section_length(element_sedes)
 
@@ -115,7 +120,7 @@ class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
 
         pairs = self._get_item_sedes_pairs(value)
         if fixed_size_section_length is None:
-            fixed_size_section_length = self.get_fixed_size_section_length(value)
+            fixed_size_section_length = self.get_fixed_size_section_length(value, pairs=pairs)
 
         variable_size_section_parts = tuple(
             sedes.serialize(item)  # slow

--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -15,6 +15,9 @@ from typing import (
 from eth_typing import (
     Hash32,
 )
+from eth_utils import (
+    to_tuple,
+)
 from eth_utils.toolz import (
     accumulate,
     concatv,
@@ -24,6 +27,7 @@ from ssz import (
     constants,
 )
 from ssz.cache.utils import (
+    _get_key,
     get_key,
 )
 from ssz.exceptions import (
@@ -91,6 +95,11 @@ def _compute_fixed_size_section_length(element_sedes: Iterable[TSedes]) -> int:
         if sedes.is_fixed_sized else constants.OFFSET_SIZE
         for sedes in element_sedes
     )
+
+
+class BasicBytesSedes(BaseSedes[TSerializable, TDeserialized]):
+    def get_key(self, value: Any) -> bytes:
+        return get_key(self, value)
 
 
 class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
@@ -175,6 +184,65 @@ class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
         return get_key(self, value)
 
 
-class BasicBytesSedes(BaseSedes[TSerializable, TDeserialized]):
-    def get_key(self, value: Any) -> bytes:
-        return get_key(self, value)
+class HomogeneousCompositeSedes(CompositeSedes[TSerializable, TDeserialized]):
+    def get_key(self, value: Any) -> str:
+        key = _get_key(self, value).hex()
+        sedes_name = type(self).__name__
+        if len(key) > 0:
+            return sedes_name + key
+        else:
+            return sedes_name + str(self.max_length)
+
+    def get_merkle_leaves(self, value: Any, cache: CacheObj) -> Tuple[Tuple[Hash32], CacheObj]:
+        merkle_leaves = ()
+        if isinstance(self.element_sedes, BasicSedes):
+            serialized_elements = tuple(
+                self.element_sedes.serialize(element)
+                for element in value
+            )
+            merkle_leaves = pack(serialized_elements)
+        else:
+            has_get_hash_tree_root_and_leaves = hasattr(
+                self.element_sedes,
+                'get_hash_tree_root_and_leaves',
+            )
+            if has_get_hash_tree_root_and_leaves:
+                merkle_leaves, cache = self.get_merkle_leaves_with_cache(
+                    value,
+                    cache,
+                )
+            else:
+                merkle_leaves = self.get_merkle_leaves_without_cache(value)
+
+        return merkle_leaves, cache
+
+    def get_merkle_leaves_with_cache(self,
+                                     value: Any,
+                                     cache: CacheObj) -> Tuple[Tuple[Hash32], CacheObj]:
+        result = self._get_merkle_leaves_with_cache(value, cache)
+        return result, cache
+
+    @to_tuple
+    def _get_merkle_leaves_with_cache(self,
+                                      value: Any,
+                                      cache: CacheObj) -> Iterable[Hash32]:
+        """
+        NOTE: cache is mutable
+        """
+        for element in value:
+            key = self.element_sedes.get_key(element)
+            if key not in cache:
+                root, cache = (
+                    self.element_sedes.get_hash_tree_root_and_leaves(element, cache)
+                )
+                cache[key] = root
+            yield cache[key]
+
+    @to_tuple
+    def get_merkle_leaves_without_cache(self, value: Any) -> Iterable[Hash32]:
+        for element in value:
+            yield self.element_sedes.get_hash_tree_root(element)
+
+
+class NonhomogeneousCompositeSedes(CompositeSedes[TSerializable, TDeserialized]):
+    ...

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -197,23 +197,24 @@ class Container(CompositeSedes[Sequence[Any], Tuple[Any, ...]]):
     def chunk_count(self) -> int:
         return len(self.field_sedes)
 
-    def serialize(self, value, fixed_size_section_length=None) -> bytes:
-        # if value._serialize_cache is not None:
-        if hasattr(value, '_serialize_cache') and value._serialize_cache is not None:
-            return value._serialize_cache
-        elif hasattr(value, '_serialize_cache') and value._serialize_cache is None:
-            value._serialize_cache = super().serialize(value, fixed_size_section_length)
-            return value._serialize_cache
+    def serialize(self, value, fixed_size_section_length=None, serialize_cache=None) -> bytes:
+        if serialize_cache is not None:
+            return serialize_cache
         else:
-            return super().serialize(value)
+            return super().serialize(value, fixed_size_section_length)
 
     def serialize_with_cache(self,
                              value: TSerializable,
-                             fixed_size_section_length_cache: int) -> Tuple[bytes, int]:
+                             fixed_size_section_length_cache: int,
+                             serialize_cache: bytes) -> Tuple[bytes, int]:
         if fixed_size_section_length_cache is None:
             fixed_size_section_length_cache = self.get_fixed_size_section_length(value)
 
-        serialized_result = self.serialize(value, fixed_size_section_length_cache)
+        serialized_result = self.serialize(
+            value,
+            fixed_size_section_length=fixed_size_section_length_cache,
+            serialize_cache=serialize_cache,
+        )
         return serialized_result, fixed_size_section_length_cache
 
     def get_key(self, value: Any) -> bytes:

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -28,7 +28,7 @@ from ssz.sedes.base import (
     TSedes,
 )
 from ssz.sedes.basic import (
-    CompositeSedes,
+    NonhomogeneousCompositeSedes,
 )
 from ssz.typing import (
     CacheObj,
@@ -52,7 +52,7 @@ def _deserialize_fixed_size_items_and_offsets(stream, field_sedes):
             yield (s_decode_offset(stream), sedes)
 
 
-class Container(CompositeSedes[Sequence[Any], Tuple[Any, ...]]):
+class Container(NonhomogeneousCompositeSedes[Sequence[Any], Tuple[Any, ...]]):
     def __init__(self, field_sedes: Sequence[TSedes]) -> None:
         if len(field_sedes) == 0:
             raise ValidationError("Cannot define container without any fields")

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -3,6 +3,7 @@ from typing import (
     IO,
     Any,
     Iterable,
+    Optional,
     Sequence,
     Tuple,
 )
@@ -90,7 +91,10 @@ class EmptyList(BaseCompositeSedes[Sequence[TSerializable], Tuple[TSerializable,
     def get_key(self, value: Any) -> bytes:
         raise NotImplementedError("Empty list does not implement `get_key`")
 
-    def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
+    def get_fixed_size_section_length(
+            self,
+            value: Sequence[TSerializable],
+            pairs: Optional[Tuple[Tuple[TSerializable, TSedes], ...]]=None) -> int:
         raise NotImplementedError("Empty list does not implement `get_fixed_size_section_length`")
 
 

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -91,6 +91,9 @@ class EmptyList(BaseCompositeSedes[Sequence[TSerializable], Tuple[TSerializable,
     def get_key(self, value: Any) -> bytes:
         raise NotImplementedError("Empty list does not implement `get_key`")
 
+    def get_fixed_size_section_length(self, value: Sequence[TSerializable]):
+        raise NotImplementedError("Empty list does not implement `get_fixed_size_section_length`")
+
 
 empty_list = EmptyList()
 

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -20,7 +20,6 @@ from eth_utils.toolz import (
 
 from ssz.cache.utils import (
     get_merkle_leaves_with_cache,
-    get_merkle_leaves_without_cache,
 )
 from ssz.constants import (
     CHUNK_SIZE,

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -396,9 +396,13 @@ class MetaSerializable(abc.ABCMeta):
     # Implement BaseSedes methods as pass-throughs to the container sedes
     #
     def serialize(cls: Type[TSerializable], value: TSerializable) -> bytes:
-        # return cls._meta.container_sedes.serialize(value)
         if value._serialize_cache is None:
-            value._serialize_cache = cls._meta.container_sedes.serialize(value)
+            value._serialize_cache, value._fixed_size_section_length_cache = (
+                cls._meta.container_sedes.serialize_with_cache(
+                    value,
+                    value._fixed_size_section_length_cache,
+                )
+            )
         return value._serialize_cache
 
     def deserialize(cls: Type[TSerializable], data: bytes) -> TSerializable:

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -401,6 +401,7 @@ class MetaSerializable(abc.ABCMeta):
                 cls._meta.container_sedes.serialize_with_cache(
                     value,
                     value._fixed_size_section_length_cache,
+                    value._serialize_cache,
                 )
             )
         return value._serialize_cache

--- a/ssz/sedes/signed_serializable.py
+++ b/ssz/sedes/signed_serializable.py
@@ -15,7 +15,7 @@ from ssz.sedes.container import (
     Container,
 )
 from ssz.sedes.serializable import (
-    BaseSerializable,
+    BasicSerializable,
     MetaSerializable,
 )
 
@@ -62,7 +62,7 @@ class MetaSignedSerializable(MetaSerializable):
 BaseSedes.register(MetaSignedSerializable)
 
 
-class SignedSerializable(BaseSerializable, metaclass=MetaSignedSerializable):
+class SignedSerializable(BasicSerializable, metaclass=MetaSignedSerializable):
     @property
     def signing_root(self):
         return ssz.get_hash_tree_root(self, self._meta.signed_container_sedes)

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -80,6 +80,10 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
         else:
             return self.length * self.element_sedes.get_fixed_size()
 
+    @property
+    def max_length(self) -> int:
+        return self.length
+
     #
     # Serialization
     #


### PR DESCRIPTION
## What was wrong?

Avoid some `hasattr` calls.

## How was it fixed?
1. `serialize_cache`
    - Add `serialize_cache` parameter to `Containe.serialize(value, fixed_size_section_length=None, serialize_cache=None) -> bytes`.
2. `fixed_size_section_length`
    - Extract `BasicSedes.get_fixed_size_section_length(value: Sequence[TSerializable], pairs: Optional[Tuple[Tuple[TSerializable, TSedes], ...]]=None)`
    - Refactor & add `fixed_size_section_length` parameter to `BasicSedes.serialize(self, value: TSerializable, fixed_size_section_length=None) -> bytes`. If the given `fixed_size_section_length` is `None`, call  `self.get_fixed_size_section_length(value, pairs)`
3. Apply cache in `Serializable` layer
    - Add `Container.serialize_with_cache(value: TSerializable, fixed_size_section_length_cache: int, serialize_cache: bytes) -> Tuple[bytes, int]`. It returns the serialized result and the `fixed_size_section_length_cache`.
    - In `MetaSerializable.serialize(value)`, it calls `cls._meta.container_sedes.serialize_with_cache(...)` for reusing and storing `value._fixed_size_section_length_cache`. 

Other change: simplify classes by removing `BaseByteSedes`.

Edit:
- Added `class HomogeneousCompositeSedes(CompositeSedes[TSerializable, TDeserialized])` for `List` and `Vector`.
- Added `class NonhomogeneousCompositeSedes(CompositeSedes[TSerializable, TDeserialized])` for `Container`.

#### Cute Animal Picture

![tmg-article_tall_wolf](https://user-images.githubusercontent.com/9263930/63698985-807c1600-c852-11e9-9030-56b4fc22d197.jpg)
