### PR TITLE
Hotfix for #87

### DIFF
--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -26,7 +26,10 @@ def get_key(sedes: TSedes, value: Any) -> str:
         return sedes_name + key
     else:
         # If the serialized result is empty, use sedes name as the key
-        return sedes_name
+        if hasattr(sedes, 'element_sedes'):
+            return sedes_name + str(sedes.max_length)
+        else:
+            return sedes_name
 
 
 @functools.lru_cache(maxsize=2**12)

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -80,6 +80,10 @@ class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedE
         else:
             return self.length * self.element_sedes.get_fixed_size()
 
+    @property
+    def max_length(self) -> int:
+        return self.length
+
     #
     # Serialization
     #


### PR DESCRIPTION
## What was wrong?

For `List`, the `sedes_name` is only `List`. Need more specific identifier.

## How was it fixed?

Add `max_length` to the `key`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
