### PR TITLE
Use as much type information as we have when building a cache key

### DIFF
--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -27,7 +27,7 @@ def get_key(sedes: TSedes, value: Any) -> str:
     else:
         # If the serialized result is empty, use sedes name as the key
         if hasattr(sedes, 'element_sedes'):
-            return sedes_name + str(sedes.max_length)
+            return f"{sedes_name}[{sedes.max_length}]({type(sedes.element_sedes).__name__})"
         else:
             return sedes_name
 


### PR DESCRIPTION
## What was wrong?

I found this while running the `v0.8.3` spec tests. In the case of `CompactCommittee` (https://github.com/ethereum/trinity/blob/master/eth2/beacon/types/compact_committees.py#L12) we have two fields that are each lists of the same size (in this scenario, `4096`).

With the current caching code, we build a cache key that is the type and size => `List4096` so that the cached hash tree root for the second field member was the first field member. Given that the fields are lists over different types,  this caused a mismatch against the spec tests.

## How was it fixed?

Use a more fine grained key for the cache.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fs-media-cache-ak0.pinimg.com%2Foriginals%2F0a%2F4b%2F7d%2F0a4b7d189d019ef1552bc8cc205fe3cd.jpg&f=1)
