### PR TITLE
Add more meta info in cache key

### DIFF
--- a/ssz/cache/utils.py
+++ b/ssz/cache/utils.py
@@ -19,21 +19,15 @@ from ssz.typing import (
 )
 
 
-def get_key(sedes: TSedes, value: Any) -> str:
-    key = _get_key(sedes, value).hex()
-    sedes_name = type(sedes).__name__
-    if len(key) > 0:
-        return sedes_name + key
-    else:
-        # If the serialized result is empty, use sedes name as the key
-        if hasattr(sedes, 'element_sedes'):
-            return sedes_name + str(sedes.max_length)
-        else:
-            return sedes_name
+def get_key(sedes, value: Any) -> str:
+    key = get_base_key(sedes, value).hex()
+    if len(key) == 0:
+        key = ''
+    return f"{sedes.get_sedes_id()}{key}"
 
 
 @functools.lru_cache(maxsize=2**12)
-def _get_key(sedes: TSedes, value: Any) -> bytes:
+def get_base_key(sedes: TSedes, value: Any) -> bytes:
     return sedes.serialize(value)
 
 

--- a/ssz/sedes/base.py
+++ b/ssz/sedes/base.py
@@ -64,7 +64,11 @@ class BaseSedes(ABC, Generic[TSerializable, TDeserialized]):
         ...
 
     @abstractmethod
-    def get_key(self, value: Any) -> bytes:
+    def get_sedes_id(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_key(self, value: Any) -> str:
         ...
 
 
@@ -72,12 +76,8 @@ TSedes = BaseSedes[Any, Any]
 
 
 class BaseCompositeSedes(BaseSedes[TSerializable, TDeserialized]):
-    @abstractmethod
-    def get_key(self, value: Any) -> bytes:
-        ...
+    ...
 
 
 class BaseByteSedes(BaseSedes[TSerializable, TDeserialized]):
-    @abstractmethod
-    def get_key(self, value: Any) -> bytes:
-        ...
+    ...

--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -80,7 +80,7 @@ class BasicSedes(BaseSedes[TSerializable, TDeserialized]):
     def chunk_count(self) -> int:
         return 1
 
-    def get_key(self, value: Any) -> bytes:
+    def get_key(self, value: Any) -> str:
         return get_key(self, value)
 
 
@@ -90,6 +90,11 @@ def _compute_fixed_size_section_length(element_sedes: Iterable[TSedes]) -> int:
         if sedes.is_fixed_sized else constants.OFFSET_SIZE
         for sedes in element_sedes
     )
+
+
+class BasicBytesSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
+    def get_key(self, value: Any) -> str:
+        return get_key(self, value)
 
 
 class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
@@ -170,10 +175,11 @@ class CompositeSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
     def _deserialize_stream(self, stream: IO[bytes]) -> TDeserialized:
         ...
 
-    def get_key(self, value: Any) -> bytes:
+    def get_key(self, value: Any) -> str:
         return get_key(self, value)
 
 
-class BasicBytesSedes(BaseCompositeSedes[TSerializable, TDeserialized]):
-    def get_key(self, value: Any) -> bytes:
-        return get_key(self, value)
+class HomogeneousCompositeSedes(CompositeSedes[TSerializable, TDeserialized]):
+    def get_sedes_id(self) -> str:
+        sedes_name = self.__class__.__name__
+        return f"{sedes_name}({self.element_sedes.get_sedes_id()},{self.max_length})"

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -95,6 +95,9 @@ class Bitlist(BasicBytesSedes[BytesOrByteArray, bytes]):
     def chunk_count(self) -> int:
         return (self.max_bit_count + 255) // 256
 
+    def get_sedes_id(self) -> str:
+        return f"{self.__class__.__name__}{self.max_bit_count}"
+
 
 def get_bitlist_len(x: int) -> int:
     return x.bit_length() - 1

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -87,3 +87,6 @@ class Bitvector(BasicBytesSedes[BytesOrByteArray, bytes]):
 
     def chunk_count(self) -> int:
         return (self.bit_count + 255) // 256
+
+    def get_sedes_id(self) -> str:
+        return f"{self.__class__.__name__}{self.bit_count}"

--- a/ssz/sedes/boolean.py
+++ b/ssz/sedes/boolean.py
@@ -33,6 +33,9 @@ class Boolean(BasicSedes[bool, bool]):
                 f"{encode_hex(data)})",
             )
 
+    def get_sedes_id(self) -> str:
+        return self.__class__.__name__
+
 
 class Bit(Boolean):
     pass

--- a/ssz/sedes/byte.py
+++ b/ssz/sedes/byte.py
@@ -27,5 +27,8 @@ class Byte(BasicSedes[bytes, bytes]):
             )
         return data
 
+    def get_sedes_id(self) -> str:
+        return self.__class__.__name__
+
 
 byte = Byte()

--- a/ssz/sedes/byte_vector.py
+++ b/ssz/sedes/byte_vector.py
@@ -80,6 +80,9 @@ class ByteVector(BasicBytesSedes[BytesOrByteArray, bytes]):
     def chunk_count(self) -> int:
         return self.length * self.size
 
+    def get_sedes_id(self) -> str:
+        return f"{self.__class__.__name__}{self.size}"
+
 
 bytes1 = ByteVector(1)
 bytes4 = ByteVector(4)

--- a/ssz/sedes/container.py
+++ b/ssz/sedes/container.py
@@ -17,9 +17,6 @@ from eth_utils.toolz import (
     sliding_window,
 )
 
-from ssz.cache.utils import (
-    get_key,
-)
 from ssz.exceptions import (
     DeserializationError,
     SerializationError,
@@ -205,5 +202,5 @@ class Container(CompositeSedes[Sequence[Any], Tuple[Any, ...]]):
         else:
             return super().serialize(value)
 
-    def get_key(self, value: Any) -> bytes:
-        return get_key(self, value)
+    def get_sedes_id(self) -> str:
+        return ','.join(field.get_sedes_id() for field in self.field_sedes)

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -37,7 +37,7 @@ from ssz.sedes.base import (
 )
 from ssz.sedes.basic import (
     BasicSedes,
-    CompositeSedes,
+    HomogeneousCompositeSedes,
 )
 from ssz.typing import (
     CacheObj,
@@ -88,7 +88,10 @@ class EmptyList(BaseCompositeSedes[Sequence[TSerializable], Tuple[TSerializable,
     def chunk_count(self) -> int:
         return 0
 
-    def get_key(self, value: Any) -> bytes:
+    def get_sedes_id(self) -> str:
+        raise NotImplementedError("Empty list does not implement `get_sedes_id`")
+
+    def get_key(self, value: Any) -> str:
         raise NotImplementedError("Empty list does not implement `get_key`")
 
 
@@ -98,7 +101,7 @@ empty_list = EmptyList()
 TSedesPairs = Tuple[Tuple[BaseSedes[TSerializable, TDeserialized], TSerializable], ...]
 
 
-class List(CompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
+class List(HomogeneousCompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]):
     def __init__(self,
                  element_sedes: TSedes,
                  max_length: int) -> None:

--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -27,7 +27,7 @@ from ssz.cache.cache import (
     DEFAULT_CACHE_SIZE,
 )
 from ssz.cache.utils import (
-    get_key,
+    get_base_key,
 )
 from ssz.constants import (
     FIELDS_META_ATTR,
@@ -223,8 +223,19 @@ class BaseSerializable(collections.Sequence):
     def hash_tree_root(self):
         return self.__class__.get_hash_tree_root(self, cache=True)
 
+    @classmethod
+    def get_sedes_id(cls) -> str:
+        # Serializable implementation name should be unique
+        return cls.__name__
+
     def get_key(self) -> bytes:
-        return get_key(self.__class__, self)
+        # Serilaize with self._meta.container_sedes
+        key = get_base_key(self._meta.container_sedes, self).hex()
+
+        if len(key) == 0:
+            key = ''
+
+        return f"{self.__class__.get_sedes_id()}{key}"
 
 
 def make_immutable(value):

--- a/ssz/sedes/uint.py
+++ b/ssz/sedes/uint.py
@@ -13,6 +13,7 @@ class UInt(BasicSedes[int, int]):
             raise ValueError(
                 "Number of bits must be a multiple of 8"
             )
+        self.num_bits = num_bits
         super().__init__(num_bits // 8)
 
     def serialize(self, value: int) -> bytes:
@@ -34,6 +35,9 @@ class UInt(BasicSedes[int, int]):
                 f"Cannot deserialize length {len(data)} byte-string as uint{self.size*8}"
             )
         return int.from_bytes(data, "little")
+
+    def get_sedes_id(self) -> str:
+        return f"{self.__class__.__name__}{self.num_bits}"
 
 
 uint8 = UInt(8)

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -33,7 +33,7 @@ from ssz.sedes.base import (
 )
 from ssz.sedes.basic import (
     BasicSedes,
-    CompositeSedes,
+    HomogeneousCompositeSedes,
 )
 from ssz.typing import (
     CacheObj,
@@ -54,7 +54,9 @@ TSedesPairs = Tuple[
 ]
 
 
-class Vector(CompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedElement, ...]]):
+class Vector(
+    HomogeneousCompositeSedes[Sequence[TSerializableElement], Tuple[TDeserializedElement, ...]]
+):
     def __init__(self,
                  element_sedes: TSedes,
                  length: int) -> None:

--- a/tests/misc/test_serializable.py
+++ b/tests/misc/test_serializable.py
@@ -2,6 +2,7 @@ import pytest
 
 import ssz
 from ssz.sedes import (
+    List,
     uint8,
 )
 
@@ -151,3 +152,18 @@ def test_root():
 
     test = Test(1, 2)
     assert test.hash_tree_root == ssz.get_hash_tree_root(test, Test)
+
+
+class Foo(ssz.Serializable):
+    ...
+
+
+@pytest.mark.parametrize(
+    ("sedes", "id"),
+    (
+        (Foo(), 'Foo'),
+        (List(Foo, 64), 'List(Foo,64)')
+    ),
+)
+def test_get_sedes_id(sedes, id):
+    assert sedes.get_sedes_id() == id

--- a/tests/sedes/test_basic_sedes.py
+++ b/tests/sedes/test_basic_sedes.py
@@ -45,3 +45,14 @@ def test_uint(bit_length, value, serialized):
     uint = UInt(bit_length)
     assert encode_hex(ssz.encode(value, uint)) == serialized
     assert ssz.decode(decode_hex(serialized), uint) == value
+
+
+@pytest.mark.parametrize(
+    ("sedes", "id"),
+    (
+        (UInt(64), 'UInt64'),
+        (boolean, 'Boolean'),
+    ),
+)
+def test_get_sedes_id(sedes, id):
+    assert sedes.get_sedes_id() == id

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -47,3 +47,13 @@ def test_bitlist_deserialize_values(size, value, expected):
 def test_bitlist_round_trip_no_sedes(size, value):
     foo = Bitlist(size)
     assert decode(encode(value, foo), foo) == value
+
+
+@pytest.mark.parametrize(
+    ("sedes", "id"),
+    (
+        (Bitlist(64), 'Bitlist64'),
+    ),
+)
+def test_get_sedes_id(sedes, id):
+    assert sedes.get_sedes_id() == id

--- a/tests/sedes/test_bitvector_serializer.py
+++ b/tests/sedes/test_bitvector_serializer.py
@@ -49,3 +49,12 @@ def test_bitvector_deserialize_values(size, value, expected):
 def test_bitvector_round_trip_no_sedes(size, value):
     foo = Bitvector(size)
     assert decode(encode(value, foo), foo) == value
+
+    @pytest.mark.parametrize(
+        ("sedes", "id"),
+        (
+            (Bitvector(64), 'Bitvector64'),
+        ),
+    )
+    def test_get_sedes_id(sedes, id):
+        assert sedes.get_sedes_id() == id

--- a/tests/sedes/test_composite_sedes.py
+++ b/tests/sedes/test_composite_sedes.py
@@ -14,6 +14,7 @@ from ssz.sedes import (
     Container,
     List,
     Vector,
+    bytes32,
     uint8,
 )
 
@@ -110,3 +111,17 @@ def test_container_of_dynamic_sized_fields(fields, value, serialized):
 
     assert encode_hex(ssz.encode(value, sedes)) == serialized
     assert ssz.decode(decode_hex(serialized), sedes) == value
+
+
+@pytest.mark.parametrize(
+    ("sedes", "id"),
+    (
+        (List(uint8, 2), 'List(UInt8,2)'),
+        (Vector(uint8, 2), 'Vector(UInt8,2)'),
+        (Container((uint8, bytes32)), 'UInt8,ByteVector32'),
+        (Container((uint8, List(uint8, 2))), 'UInt8,List(UInt8,2)'),
+        (Vector(Container((uint8, List(uint8, 2))), 2), 'Vector(UInt8,List(UInt8,2),2)'),
+    ),
+)
+def test_get_sedes_id(sedes, id):
+    assert sedes.get_sedes_id() == id

--- a/tests/sedes/test_sedes_aliases.py
+++ b/tests/sedes/test_sedes_aliases.py
@@ -71,3 +71,14 @@ def test_byte_vector_invalid_length(value, expected_length):
     properly_serialized_value = ssz.encode(value, ByteVector(len(value)))
     with pytest.raises(DeserializationError):
         ssz.decode(properly_serialized_value, byte_vector)
+
+
+@pytest.mark.parametrize(
+    ("sedes", "id"),
+    (
+        (byte, 'Byte'),
+        (ByteVector(64), 'ByteVector64')
+    ),
+)
+def test_get_sedes_id(sedes, id):
+    assert sedes.get_sedes_id() == id


### PR DESCRIPTION
## What was wrong?

Replace #90

Thanks to @ralexstokes for finding this bug!

## How was it fixed?

1. Apply partial #88 refactoring: split `CompositeSedes` into two subclasses `HomogeneousCompositeSedes` (including `List` and `Vector`) and `Container` (nonhomogeneous).
2. Add `get_sedes_id` API to identify the sedes for cache key.
    - `Boolean` or `Byte`
        - just return the class name `Boolean` or `Byte`.
    - `UInt`
        - return `f'UInt{bit_length}'`.
    - `ByteVector`, `Bitlist`, `Bitvector`
        - return `'f{sedes.__class__.name}{length}'`.
    - `HomogeneousCompositeSedes`
        - use `element_sedes.get_sedes_id()` and `max_length` and as the ID. e.g., `List(uint8, 2)` -> `'List(UInt8,2)'`
    - `Container`
        - use `','.join(field.get_sedes_id() for field in self.field_sedes)` as the ID. e.g., `Container((uint8, bytes32))` -> `'UInt8,ByteVector32'`.
    - `Serializable`
        - use the class name as the ID. e.g., `class Foo(Serializable)` -> `'Foo'`.
3. Generalize `get_key`
    - return `f"{sedes.get_sedes_id()}{key}"`


#### Cute Animal Picture

![pets-4415649_640](https://user-images.githubusercontent.com/9263930/64067245-11d6f800-cc58-11e9-9316-d4a64c76ff9f.jpg)
