### PR TITLE
Fix copy cache

### DIFF
--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -188,6 +188,7 @@ class BaseSerializable(collections.Sequence):
         all_kwargs = merge_args_to_kwargs(args, combined_kwargs, self._meta.field_names)
 
         result = type(self)(**all_kwargs)
+        result.cache = self.cache
 
         return result
 


### PR DESCRIPTION
## What was wrong?

It was removed when I used simple `dict` as the `cache`. Now it should be safe with `LRU` cache.

## How was it fixed?

When `b = a.copy()`, set the `b.cache` to `a.cache`.

#### Cute Animal Picture

![cat-2536662_640](https://user-images.githubusercontent.com/9263930/64151102-40bdbb80-ce5c-11e9-9804-2293ab983752.jpg)
