### PR TITLE
Tree Hash Object

### DIFF
--- a/scripts/benchmark/hash_tree.py
+++ b/scripts/benchmark/hash_tree.py
@@ -1,0 +1,60 @@
+from contextlib import contextmanager
+from itertools import chain
+import random
+import time
+
+from ssz.hash_tree import HashTree
+from ssz.utils import merkleize_with_cache
+
+NUM_CHUNKS = 1000000
+NUM_UPDATES = 100
+
+
+def get_random_chunk():
+    return bytes(random.randint(0, 255) for _ in range(32))
+
+
+@contextmanager
+def benchmark(message):
+    start_time = time.time()
+    yield
+    end_time = time.time()
+    print(message, f"{end_time - start_time} s")
+
+
+if __name__ == "__main__":
+    with benchmark(f"Preparing {NUM_CHUNKS} chunks"):
+        chunks = [get_random_chunk() for _ in range(NUM_CHUNKS)]
+        update_indices = random.sample(list(range(NUM_CHUNKS)), NUM_UPDATES)
+
+    print()
+    print("-- Merkleize --")
+    cache = {}
+    with benchmark(f"First root access"):
+        merkleize_with_cache(chunks, cache)
+
+    with benchmark(f"Second root access"):
+        merkleize_with_cache(chunks, cache)
+
+    for update_index in update_indices:
+        chunks[update_index] = get_random_chunk()
+    with benchmark(f"Update and root access"):
+        merkleize_with_cache(chunks, cache)
+
+    print()
+    print("-- Hash tree -- ")
+
+    with benchmark(f"First root access"):
+        hash_tree = HashTree.compute(chunks)
+        hash_tree.root
+
+    with benchmark(f"Second root access"):
+        hash_tree.root
+
+    with benchmark(f"Update and root access"):
+        updates = chain(
+            *((update_index, get_random_chunk()) for update_index in update_indices)
+        )
+
+        updated_hash_tree = hash_tree.mset(*updates)
+        updated_hash_tree.root

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email="ethcalibur+pip@gmail.com",
     url="https://github.com/ethereum/py-ssz",
     include_package_data=True,
-    install_requires=["eth-utils>=1,<2", "lru-dict>=1.1.6"],
+    install_requires=["eth-utils>=1,<2", "lru-dict>=1.1.6", "pyrsistent>=0.15.4,<0.16"],
     setup_requires=["setuptools-markdown"],
     python_requires=">=3.6, <4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,13 @@ setup(
     author_email="ethcalibur+pip@gmail.com",
     url="https://github.com/ethereum/py-ssz",
     include_package_data=True,
-    install_requires=["eth-utils>=1,<2", "lru-dict>=1.1.6", "pyrsistent>=0.15.4,<0.16"],
+    install_requires=[
+        "eth-utils>=1,<2",
+        "lru-dict>=1.1.6",
+        # When updating to a newer version of pyrsistent, please check that the interface
+        # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)
+        "pyrsistent==0.15.4",
+    ],
     setup_requires=["setuptools-markdown"],
     python_requires=">=3.6, <4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
         "ruamel.yaml==0.15.87",
         "mypy-extensions>=0.4.1,<1.0.0",
     ],
-    "lint": ["flake8==3.4.1", "isort==4.3.21", "black==19.3b"],
+    "lint": ["flake8==3.7.8", "isort==4.3.21", "black==19.3b"],
     "doc": ["Sphinx>=1.6.5,<2", "sphinx_rtd_theme>=0.1.9"],
     "dev": ["bumpversion>=0.5.3,<1", "wheel", "twine", "ipython", "pre-commit==1.18.3"],
 }

--- a/ssz/hash_tree.py
+++ b/ssz/hash_tree.py
@@ -3,6 +3,9 @@ import itertools
 from numbers import Integral
 from typing import Any, Generator, Iterable, Optional, Union
 
+# `transform` comes from a non-public API which is considered stable, but future changes can not be
+# ruled out completely. Therefore, the implementation should be reviewed whenever pyrsistent is
+# updated. See https://github.com/tobgu/pyrsistent/issues/180 for more information.
 from eth_typing import Hash32
 from eth_utils.toolz import drop, iterate, partition, pipe, take
 from pyrsistent import pmap, pvector

--- a/ssz/hash_tree.py
+++ b/ssz/hash_tree.py
@@ -1,0 +1,394 @@
+from functools import partial
+import itertools
+from numbers import Integral
+from typing import Any, Generator, Iterable, Optional, Union
+
+from eth_typing import Hash32
+from eth_utils.toolz import drop, iterate, partition, pipe, take
+from pyrsistent import pmap, pvector
+from pyrsistent._transformations import transform
+from pyrsistent.typing import PMap, PVector
+
+from ssz.constants import ZERO_HASHES
+from ssz.hash import hash_eth2
+from ssz.utils import get_next_power_of_two
+
+RawHashTreeLayer = PVector[Hash32]
+RawHashTree = PVector[RawHashTreeLayer]
+
+
+def validate_limit(limit: Optional[int]) -> None:
+    if limit is not None:
+        if limit <= 0:
+            raise ValueError(f"Limit is not positive: {limit}")
+        if 2 ** (limit.bit_length() - 1) != limit:
+            raise ValueError(f"Limit is not a power of two: {limit}")
+
+
+def validate_raw_hash_tree(raw_hash_tree: RawHashTree, limit: Optional[int]) -> None:
+    if len(raw_hash_tree) == 0:
+        raise ValueError("Hash tree is empty")
+
+    if len(raw_hash_tree[0]) == 0:
+        raise ValueError("Hash tree contains zero chunks")
+
+    if limit is not None and len(raw_hash_tree[0]) > limit:
+        raise ValueError(
+            f"Hash tree contains {len(raw_hash_tree[0])} chunks which exceeds limit {limit}"
+        )
+
+    if len(raw_hash_tree[-1]) != 1:
+        raise ValueError(
+            f"Hash tree root layer contains {len(raw_hash_tree[-1])} items instead of 1"
+        )
+
+
+class HashTree(PVector[Hash32]):
+    def __init__(self, raw_hash_tree: RawHashTree, limit: Optional[int] = None) -> None:
+        validate_limit(limit)
+        validate_raw_hash_tree(raw_hash_tree, limit)
+
+        self.limit = limit
+        self.raw_hash_tree = raw_hash_tree
+
+    @classmethod
+    def compute(
+        cls, chunks: Iterable[Hash32], limit: Optional[int] = None
+    ) -> "HashTree":
+        raw_hash_tree = compute_hash_tree(chunks, limit)
+        return cls(raw_hash_tree, limit)
+
+    @property
+    def chunks(self) -> RawHashTreeLayer:
+        return self.raw_hash_tree[0]
+
+    @property
+    def root(self) -> Hash32:
+        return self.raw_hash_tree[-1][0]
+
+    def transform(self, *transformations):
+        return transform(self, transformations)
+
+    def evolver(self):
+        return HashTreeEvolver(self)
+
+    #
+    # Comparison
+    #
+    def __hash__(self) -> int:
+        return hash((self.root, self.limit))
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, HashTree)
+            and self.root == other.root
+            and self.limit == other.limit
+        )
+
+    #
+    # Chunk access
+    #
+    def __len__(self) -> int:
+        return len(self.chunks)
+
+    def __getitem__(self, index: Union[int, slice]) -> Hash32:
+        return self.chunks[index]
+
+    def index(self, value: Hash32, *args, **kwargs) -> Hash32:
+        return self.chunks.index(value, *args, **kwargs)
+
+    def count(self, value: Hash32) -> int:
+        return self.chunks.count(value)
+
+    #
+    # Tree modifications via evolver
+    #
+    def append(self, value: Hash32) -> "HashTree":
+        evolver = self.evolver()
+        evolver.append(value)
+        return evolver.persistent()
+
+    def extend(self, value: Iterable[Hash32]) -> "HashTree":
+        evolver = self.evolver()
+        evolver.extend(value)
+        return evolver.persistent()
+
+    def __add__(self, other: Iterable[Hash32]) -> "HashTree":
+        return self.extend(other)
+
+    def __mul__(self, times: int) -> "HashTree":
+        if times <= 0:
+            raise ValueError(f"Multiplier must be greater or equal to 1, got {times}")
+
+        evolver = self.evolver()
+
+        for _ in range(times - 1):
+            evolver.extend(self)
+
+        return evolver.persistent()
+
+    def mset(self, *args: Union[int, Hash32]) -> "HashTree":
+        if len(args) % 2 != 0:
+            raise TypeError(
+                f"mset must be called with an even number of arguments, got {len(args)}"
+            )
+
+        evolver = self.evolver()
+        for index, value in partition(2, args):
+            evolver[index] = value
+        return evolver.persistent()
+
+    def set(self, index: int, value: Hash32) -> "HashTree":
+        return self.mset(index, value)
+
+    #
+    # Removal of chunks
+    #
+    def delete(self, index: int, stop: Optional[int] = None) -> "HashTree":
+        if stop is None:
+            stop = index + 1
+        chunks = self.chunks.delete(index, stop)
+        return self.__class__.compute(chunks, self.limit)
+
+    def remove(self, value: Hash32) -> "HashTree":
+        chunks = self.chunks.remove(value)
+        return self.__class__.compute(chunks, self.limit)
+
+
+class HashTreeEvolver:
+    def __init__(self, hash_tree: "HashTree") -> None:
+        self.original_hash_tree = hash_tree
+        self.updated_chunks: PMap[int, Hash32] = pmap()
+        self.appended_chunks: PVector[Hash32] = pvector()
+
+    #
+    # Getters
+    #
+    def __getitem__(self, index: int) -> Hash32:
+        if index < 0:
+            index += len(self)
+
+        if index in self.updated_chunks:
+            return self.updated_chunks[index]
+        else:
+            if 0 <= index < len(self.original_hash_tree):
+                return self.original_hash_tree[index]
+            elif index < len(self):
+                index_in_appendix = index - len(self.original_hash_tree)
+                return self.appended_chunks[index_in_appendix]
+            else:
+                raise IndexError(f"Index out of bounds: {index}")
+
+    def __len__(self) -> int:
+        return len(self.original_hash_tree) + len(self.appended_chunks)
+
+    def is_dirty(self) -> bool:
+        return self.updated_chunks or self.appended_chunks
+
+    #
+    # Setters
+    #
+    def set(self, index: Integral, value: Hash32) -> None:
+        self[index] = value
+
+    def __setitem__(self, index: Integral, value: Hash32) -> None:
+        if index < 0:
+            index += len(self)
+
+        if 0 <= index < len(self.original_hash_tree):
+            self.updated_chunks = self.updated_chunks.set(index, value)
+        elif index < len(self):
+            index_in_appendix = index - len(self.original_hash_tree)
+            self.appended_chunks = self.appended_chunks.set(index_in_appendix, value)
+        else:
+            raise IndexError(f"Index out of bounds: {index}")
+
+    #
+    # Length changing modifiers
+    #
+    def append(self, value: Hash32) -> None:
+        self.appended_chunks = self.appended_chunks.append(value)
+        self._check_limit()
+
+    def extend(self, values: Iterable[Hash32]) -> None:
+        self.appended_chunks = self.appended_chunks.extend(values)
+        self._check_limit()
+
+    def _check_limit(self) -> None:
+        limit = self.original_hash_tree.limit
+        if limit is not None and len(self) > limit:
+            raise ValueError("Hash tree exceeds size limit {limit}")
+
+    #
+    # Not implemented
+    #
+    def delete(self, index, stop=None):
+        raise NotImplementedError()
+
+    def __delitem__(self, index):
+        raise NotImplementedError()
+
+    def remove(self, value):
+        raise NotImplementedError()
+
+    #
+    # Persist
+    #
+    def persistent(self) -> "HashTree":
+        if not self.is_dirty():
+            return self.original_hash_tree
+        else:
+            setters = (
+                partial(set_chunk_in_tree, index=index, chunk=chunk)
+                for index, chunk in self.updated_chunks.items()
+            )
+            appenders = (
+                partial(append_chunk_to_tree, chunk=chunk)
+                for chunk in self.appended_chunks
+            )
+            raw_hash_tree = pipe(
+                self.original_hash_tree.raw_hash_tree, *setters, *appenders
+            )
+            return self.original_hash_tree.__class__(
+                raw_hash_tree, self.original_hash_tree.limit
+            )
+
+
+def hash_layer(child_layer: RawHashTreeLayer, layer_index: int) -> RawHashTreeLayer:
+    if len(child_layer) % 2 == 0:
+        padded_child_layer = child_layer
+    else:
+        padded_child_layer = child_layer.append(ZERO_HASHES[layer_index])
+
+    child_pairs = partition(2, padded_child_layer)
+    parent_layer = pvector(
+        hash_eth2(left_child + right_child) for left_child, right_child in child_pairs
+    )
+    return parent_layer
+
+
+def generate_hash_tree_layers(
+    chunks: RawHashTreeLayer
+) -> Generator[RawHashTreeLayer, None, None]:
+    yield chunks
+    previous_layer = chunks
+
+    for previous_layer_index in itertools.count():
+        # stop if the root has been reached
+        if len(previous_layer) <= 1:
+            break
+        if previous_layer_index > 1000:
+            raise Exception("Invariant: Root is reached quickly")
+
+        next_layer = hash_layer(previous_layer, previous_layer_index)
+
+        yield next_layer
+        previous_layer = next_layer
+
+
+def get_num_layers(num_chunks: int, limit: Optional[int]) -> int:
+    if limit is not None:
+        virtual_size = limit
+    else:
+        virtual_size = num_chunks
+
+    return get_next_power_of_two(virtual_size).bit_length()
+
+
+def generate_chunk_tree_padding(
+    unpadded_chunk_tree: PVector[Hash32], limit: Optional[int]
+) -> Generator[Hash32, None, None]:
+    if limit is None:
+        return
+
+    num_chunks = len(unpadded_chunk_tree[0])
+    if num_chunks > limit:
+        raise ValueError(
+            f"Number of chunks in tree ({num_chunks}) exceeds limit {limit}"
+        )
+
+    num_existing_layers = len(unpadded_chunk_tree)
+    num_target_layers = get_next_power_of_two(limit).bit_length()
+
+    previous_root = unpadded_chunk_tree[-1][0]
+    for previous_layer_index in range(num_existing_layers - 1, num_target_layers - 1):
+        next_root = hash_eth2(previous_root + ZERO_HASHES[previous_layer_index])
+        yield pvector([next_root])
+        previous_root = next_root
+
+
+def pad_hash_tree(
+    unpadded_chunk_tree: RawHashTree, limit: Optional[int] = None
+) -> RawHashTree:
+    padding = pvector(generate_chunk_tree_padding(unpadded_chunk_tree, limit))
+    return unpadded_chunk_tree + padding
+
+
+def compute_hash_tree(
+    chunks: Iterable[Hash32], limit: Optional[int] = None
+) -> RawHashTree:
+    validate_limit(limit)
+
+    chunks = pvector(chunks)
+
+    if not chunks:
+        raise ValueError("Number of chunks is 0")
+    if limit is not None and len(chunks) > limit:
+        raise ValueError(f"Number of chunks ({len(chunks)}) exceeds limit ({limit})")
+
+    unpadded_chunk_tree = pvector(generate_hash_tree_layers(chunks))
+    return pad_hash_tree(unpadded_chunk_tree, limit)
+
+
+def recompute_hash_in_tree(
+    hash_tree: RawHashTree, layer_index: int, hash_index: int
+) -> RawHashTree:
+    if layer_index == 0:
+        raise ValueError(
+            "Cannot recompute hash in leaf layer as it consists of chunks not hashes"
+        )
+
+    child_layer_index = layer_index - 1
+    left_child_hash_index = hash_index * 2
+    right_child_hash_index = left_child_hash_index + 1
+
+    child_layer = hash_tree[child_layer_index]
+    left_child_hash = child_layer[left_child_hash_index]
+    try:
+        right_child_hash = child_layer[right_child_hash_index]
+    except IndexError:
+        right_child_hash = ZERO_HASHES[child_layer_index]
+
+    # create the layer if it doesn't exist yet (otherwise, pyrsistent would create a PMap)
+    if layer_index == len(hash_tree):
+        hash_tree = hash_tree.append(pvector())
+
+    parent_hash = hash_eth2(left_child_hash + right_child_hash)
+    return hash_tree.transform((layer_index, hash_index), parent_hash)
+
+
+def set_chunk_in_tree(hash_tree: RawHashTree, index: int, chunk: Hash32) -> RawHashTree:
+    hash_tree_with_updated_chunk = hash_tree.transform((0, index), chunk)
+
+    parent_layer_indices = drop(1, range(len(hash_tree)))
+    parent_hash_indices = drop(
+        1, take(len(hash_tree), iterate(lambda index: index // 2, index))
+    )
+
+    update_functions = (
+        partial(recompute_hash_in_tree, layer_index=layer_index, hash_index=hash_index)
+        for layer_index, hash_index in zip(parent_layer_indices, parent_hash_indices)
+    )
+
+    hash_tree_with_updated_branch = pipe(
+        hash_tree_with_updated_chunk, *update_functions
+    )
+
+    if len(hash_tree_with_updated_branch[-1]) == 1:
+        return hash_tree_with_updated_branch
+    elif len(hash_tree_with_updated_branch[-1]) == 2:
+        return recompute_hash_in_tree(hash_tree_with_updated_branch, len(hash_tree), 0)
+
+
+def append_chunk_to_tree(hash_tree: RawHashTree, chunk: Hash32) -> RawHashTree:
+    return set_chunk_in_tree(hash_tree, len(hash_tree[0]), chunk)

--- a/ssz/utils.py
+++ b/ssz/utils.py
@@ -3,7 +3,6 @@ import functools
 from typing import IO, Any, Sequence, Tuple
 
 from eth_typing import Hash32
-from eth_utils.toolz import partition
 
 from ssz.constants import BASE_TYPES, CHUNK_SIZE, EMPTY_CHUNK, OFFSET_SIZE, ZERO_HASHES
 from ssz.exceptions import DeserializationError
@@ -105,17 +104,6 @@ def get_next_power_of_two(value: int) -> int:
         return 1
     else:
         return 2 ** (value - 1).bit_length()
-
-
-def hash_layer(child_layer: Sequence[bytes]) -> Tuple[Hash32, ...]:
-    if len(child_layer) % 2 != 0:
-        raise ValueError("Layer must have an even number of elements")
-
-    child_pairs = partition(2, child_layer)
-    parent_layer = tuple(
-        hash_eth2(left_child + right_child) for left_child, right_child in child_pairs
-    )
-    return parent_layer
 
 
 def _get_chunk_and_max_depth(

--- a/tests/tree_hash/test_hash_tree.py
+++ b/tests/tree_hash/test_hash_tree.py
@@ -1,0 +1,153 @@
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from pyrsistent import pvector
+import pytest
+
+from ssz.constants import ZERO_HASHES
+from ssz.hash_tree import HashTree
+from ssz.utils import merkleize
+
+
+#
+# Strategies
+#
+def limit_st():
+    return st.one_of(
+        st.none(),
+        st.builds(lambda power: 2 ** power, st.integers(min_value=0, max_value=5)),
+    )
+
+
+def chunk_st():
+    return st.binary(min_size=32, max_size=32)
+
+
+@st.composite
+def chunks_and_limit_st(draw):
+    limit = draw(limit_st())
+    if limit:
+        max_size = limit
+    else:
+        max_size = 5
+    chunks = draw(st.lists(chunk_st(), min_size=1, max_size=max_size))
+    return pvector(chunks), limit
+
+
+def hash_tree_st():
+    return st.builds(
+        lambda chunks_and_limit: HashTree.compute(*chunks_and_limit),
+        chunks_and_limit_st(),
+    )
+
+
+#
+# Tests
+#
+@given(chunks_and_limit_st())
+def test_compute(chunks_and_limit):
+    root = merkleize(*chunks_and_limit)
+    hash_tree = HashTree.compute(*chunks_and_limit)
+    assert hash_tree.chunks == chunks_and_limit[0]
+    assert hash_tree.root == root
+    assert hash_tree.limit == chunks_and_limit[1]
+
+
+@pytest.mark.parametrize(
+    ("chunks", "limit"),
+    (
+        ([], None),
+        ([ZERO_HASHES[0]], -1),
+        ([ZERO_HASHES[0]], 3),
+        ([ZERO_HASHES[0]] * 2, 1),
+        ([ZERO_HASHES[0]] * 3, 2),
+    ),
+)
+def test_invalid_hash_tree(chunks, limit):
+    with pytest.raises(ValueError):
+        HashTree.compute(chunks, limit)
+
+
+@given(chunks_and_limit_st())
+def test_equal(chunks_and_limit):
+    hash_tree_a = HashTree.compute(*chunks_and_limit)
+    hash_tree_b = HashTree.compute(*chunks_and_limit)
+    assert hash_tree_a == hash_tree_b
+    assert hash(hash_tree_a) == hash(hash_tree_b)
+
+
+@given(st.lists(chunks_and_limit_st(), min_size=2, max_size=2, unique=True))
+def test_not_equal(chunks_and_limits):
+    hash_tree_a = HashTree.compute(*chunks_and_limits[0])
+    hash_tree_b = HashTree.compute(*chunks_and_limits[1])
+    assert hash_tree_a != hash_tree_b
+    assert hash(hash_tree_a) != hash(hash_tree_b)
+
+
+@given(hash_tree_st())
+def test_len(hash_tree):
+    assert len(hash_tree) == len(hash_tree.chunks)
+
+
+@given(hash_tree_st())
+def test_get_item(hash_tree):
+    for index in range(len(hash_tree)):
+        negative_index = index - len(hash_tree)
+        assert hash_tree[index] == hash_tree.chunks[index]
+        assert hash_tree[negative_index] == hash_tree.chunks[negative_index]
+
+
+@given(hash_tree_st())
+def test_index(hash_tree):
+    for chunk in hash_tree:
+        assert hash_tree.index(chunk) == hash_tree.chunks.index(chunk)
+
+
+@given(hash_tree_st())
+def test_count(hash_tree):
+    for chunk in hash_tree:
+        assert hash_tree.count(chunk) == hash_tree.chunks.count(chunk)
+
+
+@given(hash_tree_st(), chunk_st())
+def test_append(hash_tree, chunk):
+    # extend limit if necessary
+    if hash_tree.limit is not None and len(hash_tree) == hash_tree.limit:
+        hash_tree = HashTree.compute(hash_tree.chunks, hash_tree.limit * 2)
+
+    result = HashTree.compute(hash_tree.chunks.append(chunk), hash_tree.limit)
+    assert hash_tree.append(chunk) == result
+
+
+@given(hash_tree_st(), st.lists(chunk_st()))
+def test_extend(hash_tree, chunks):
+    # only extend up to limit
+    if hash_tree.limit is not None:
+        chunks = chunks[: hash_tree.limit - len(hash_tree)]
+    result = HashTree.compute(hash_tree.chunks.extend(chunks), limit=hash_tree.limit)
+    assert hash_tree.extend(chunks) == result
+    assert hash_tree + chunks == result
+
+
+@given(hash_tree_st(), chunk_st())
+def test_set(hash_tree, chunk):
+    for index in range(len(hash_tree)):
+        result = HashTree.compute(hash_tree.chunks.set(index, chunk), hash_tree.limit)
+        assert hash_tree.set(index, chunk) == result
+
+
+@given(hash_tree_st())
+def test_delete(hash_tree):
+    assume(len(hash_tree) > 1)
+
+    for index in range(len(hash_tree)):
+        result = HashTree.compute(hash_tree.chunks.delete(index), hash_tree.limit)
+        assert hash_tree.delete(index) == result
+
+
+@given(hash_tree_st())
+def test_remove(hash_tree):
+    for chunk in hash_tree:
+        chunks = hash_tree.chunks.remove(chunk)
+        assume(len(chunks) >= 1)
+        result = HashTree.compute(chunks, hash_tree.limit)
+        assert hash_tree.remove(chunk) == result

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist=
 [isort]
 force_sort_within_sections=True
 include_trailing_comma=True
-known_third_party = eth_typing,eth_utils,hypothesis,lru,pytest,ruamel,setuptools,yaml_test_execution
+known_third_party = eth_typing,eth_utils,hypothesis,lru,pyrsistent,pytest,ruamel,setuptools,yaml_test_execution
 line_length=88
 multi_line_output=3
 use_parentheses=True


### PR DESCRIPTION
This PR implements a class representing tree hashes. It is immutable and provides the same interface as a pyrsistent pvector, with entries corresponding to chunks. The full tree is stored and on updates only the affected hashes are recomputed.

Example usage:

```Py
hash_tree_1 = HashTree.compute([CHUNK1, CHUNK2], limit=4)  # create a new hash tree
hash_tree_2 = hash_tree_1.set(0, CHUNK3)  # update chunk 0
hash_tree_3 = hash_tree_2.append(CHUNK4)  # append a chunk at the end
print(hash_tree_3[1])  # access chunk 1
print(hash_tree_3.root)  # access root
hash_tree_4 = hash_tree_3.delete(2)  # delete chunk 2 (this recomputes the full tree at the moment)

evolver = hash_tree_4.evolver()  # mutable copy
evolver[1] = CHUNK1
evolver[2].append(CHUNK23)
hash_tree_5 = evolver.persist()  # persist mutable copy
```

The goal is to use this internally as a simple way to cache hash trees in the future. We would have to write `HashableList`, `HashableVector`, and a new version of `Serializable` that owns a tree hash so that it can create copies of itself efficiently.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/67466551-d534e500-f679-11e9-820d-71aceccad526.jpg)
