### PR TITLE
Add passthrough for hashables in hashablify_value

### DIFF
--- a/ssz/hashable_container.py
+++ b/ssz/hashable_container.py
@@ -240,6 +240,9 @@ else:
 
 
 def hashablify_value(value: Any, sedes: BaseSedes) -> Any:
+    if isinstance(value, (HashableContainer, HashableList, HashableVector)):
+        return value
+
     if isinstance(sedes, List):
         return HashableList.from_iterable(value, sedes)
     elif isinstance(sedes, Vector):


### PR DESCRIPTION
## What was wrong?

`hashablify_value` used to convert everything to iterables which requires recomputation of the hash tree.

## How was it fixed?

Just return the original value if it already is hashable.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/2c/46/53/2c4653abf7ca6b7ee446c845cff39315--ladybird-ladybird-lady-bugs.jpg)
