### PR TITLE
Update Hypothesis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
         "pytest-xdist==1.28.0",
         "pytest-watch>=4.1.0,<5",
         "tox>=2.9.1,<3",
-        "hypothesis==3.69.5",
+        "hypothesis==4.54.0",
         "ruamel.yaml==0.15.87",
         "mypy-extensions>=0.4.1,<1.0.0",
     ],

--- a/tests/hashable/hashable_strategies.py
+++ b/tests/hashable/hashable_strategies.py
@@ -134,7 +134,7 @@ def general_list_sedes_and_values_st(draw, element_sedes_and_elements, size=None
 
     if size is None:
         size = draw(st.integers(min_value=1, max_value=10))
-    max_size = draw(st.integers(min_value=size))
+    max_size = draw(st.integers(min_value=size, max_value=1024))
 
     sedes = List(element_sedes, max_length=max_size)
     values = st.lists(elements, min_size=size, max_size=size)


### PR DESCRIPTION
- Update hypothesis version. The old version broke, presumably because of some unpinned dependency on their side.
- Fix list test value generation. The new hypothesis version creates list sedes objects with unrealistically large `max_lengths`. We "only" support up to `2**100` because of the number of `ZERO_HASHES` we've pregenerated, so the test fails. To fix this, I've given `max_length` a maximum value of 1024.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/9a/2e/b4/9a2eb40942fb40273251ea43788c13ba.jpg)
