### PR TITLE
Fix deprecation warning

### DIFF
--- a/ssz/sedes/serializable.py
+++ b/ssz/sedes/serializable.py
@@ -1,5 +1,5 @@
 import abc
-import collections
+import collections.abc
 import copy
 import operator
 import re
@@ -67,7 +67,7 @@ def merge_args_to_kwargs(args, kwargs, arg_names):
         yield name, value
 
 
-class BaseSerializable(collections.Sequence):
+class BaseSerializable(collections.abc.Sequence):
     cache = None
 
     def __init__(self, *args, cache=None, **kwargs):


### PR DESCRIPTION
## What was wrong?

A deprecated import is causing a warning downstream in Trinity.

```
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/ssz/sedes/serializable.py:70: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class BaseSerializable(collections.Sequence):
```

## How was it fixed?

Import `Sequence` from `collections.abc` rather than `collections`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.superiorwallpapers.com/images/lthumbs/2016-04/11744_Sweet-kiss-form-your-son-leon-wild-animal.jpg)
