### PR TITLE
Remove pyrsistent pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "lru-dict>=1.1.6",
         # When updating to a newer version of pyrsistent, please check that the interface
         # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)
-        "pyrsistent==0.15.6",
+        "pyrsistent>=0.15.6,<0.16",
     ],
     setup_requires=["setuptools-markdown"],
     python_requires=">=3.6, <4",


### PR DESCRIPTION
## What was wrong?

The pin resulted in dependency conflicts with other libraries required by Trinity.

## How was it fixed?

Remove the pin

#### Cute Animal Picture
![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/71980195-c7761100-321f-11ea-8ff5-05a9e67f4eaf.jpg)