### PR TITLE
Prevent bitvectors of length 0

### DIFF
--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -18,8 +18,8 @@ BytesOrByteArray = Union[bytes, bytearray]
 
 class Bitvector(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
     def __init__(self, bit_count: int) -> None:
-        if bit_count < 0:
-            raise TypeError("Bit count cannot be negative")
+        if bit_count <= 0:
+            raise TypeError("Bit count cannot be zero or negative")
         self.bit_count = bit_count
 
     #

--- a/tests/sedes/test_bitvector_instantiation.py
+++ b/tests/sedes/test_bitvector_instantiation.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ssz.sedes import Bitvector
+
+
+def test_bitvector_instantiation_bound():
+    with pytest.raises(TypeError):
+        bit_count = 0
+        Bitvector(bit_count)

--- a/tests/sedes/test_bitvector_serializer.py
+++ b/tests/sedes/test_bitvector_serializer.py
@@ -7,7 +7,6 @@ from ssz.sedes import Bitlist, Bitvector, Vector, boolean
 @pytest.mark.parametrize(
     "size, value, expected",
     (
-        (0, (), b""),
         (16, (True,) + (False,) * 15, b"\x01\x00"),
         (16, (False,) + (True,) + (False,) * 14, b"\x02\x00"),
         (16, (False,) * 15 + (True,), b"\x00\x80"),
@@ -23,7 +22,6 @@ def test_bitvector_serialize_values(size, value, expected):
 @pytest.mark.parametrize(
     "size, value,expected",
     (
-        (0, b"", ()),
         (16, b"\x01\x00", (True,) + (False,) * 15),
         (16, b"\x02\x00", (False,) + (True,) + (False,) * 14),
         (16, b"\x00\x80", (False,) * 15 + (True,)),


### PR DESCRIPTION
## What was wrong?

According to the spec, an empty bitvector is illegal and so an error should be raised if bit_count <=0

Issue #111

## How was it fixed?

The bound on bit_count was adjusted so that an error is raised if it is zero or negative

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media-cdn.tripadvisor.com/media/photo-s/11/59/bd/7c/wombat.jpg)
