### PR TITLE
Deserialise seq of bytes into bitlist only if last byte is non null

### DIFF
--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -59,6 +59,12 @@ class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
         as_integer = int.from_bytes(data, "little")
         len_value = get_bitlist_len(as_integer)
 
+        # Last byte in bytes should be >= 1, if not data is not a serialised bitlist.
+        if data[len(data) - 1] == 0:
+            raise DeserializationError(
+                f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] as last byte is null [{data[len(data) - 1]}]"
+            )
+
         if len_value > self.max_bit_count:
             raise DeserializationError(
                 f"Cannot deserialize length {len_value} bytes data as Bitlist[{self.max_bit_count}]"

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -60,7 +60,7 @@ class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
         # Length of data should be larger than 1
         if len(data) < 1:
             raise DeserializationError(
-                f"Cannot deserialize emoty bytes data as Bitlist[{self.max_bit_count}] "
+                f"Cannot deserialize empty bytes string as Bitlist[{self.max_bit_count}] "
             )
 
         #   Last byte in bytes should be >= 1, if not data is not a serialised bitlist.

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -62,7 +62,7 @@ class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
         # Last byte in bytes should be >= 1, if not data is not a serialised bitlist.
         if data[len(data) - 1] == 0:
             raise DeserializationError(
-                f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] "\
+                f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] "
                 f"as last byte is null [{data[len(data) - 1]}]"
             )
 

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -62,7 +62,8 @@ class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
         # Last byte in bytes should be >= 1, if not data is not a serialised bitlist.
         if data[len(data) - 1] == 0:
             raise DeserializationError(
-                f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] as last byte is null [{data[len(data) - 1]}]"
+                f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] "\
+                f"as last byte is null [{data[len(data) - 1]}]"
             )
 
         if len_value > self.max_bit_count:

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -56,15 +56,23 @@ class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
     #
     @to_tuple
     def deserialize(self, data: bytes) -> Tuple[bool, ...]:
-        as_integer = int.from_bytes(data, "little")
-        len_value = get_bitlist_len(as_integer)
 
-        # Last byte in bytes should be >= 1, if not data is not a serialised bitlist.
-        if data[len(data) - 1] == 0:
+        # Length of data should be larger than 1
+        if len(data) < 1:
+            raise DeserializationError(
+                f"Cannot deserialize emoty bytes data as Bitlist[{self.max_bit_count}] "
+            )
+
+        #   Last byte in bytes should be >= 1, if not data is not a serialised bitlist.
+        #   len(data) >= 1 and data has a last element that can be compared to 0x00
+        if data[-1] == 0:
             raise DeserializationError(
                 f"Cannot deserialize bytes data as Bitlist[{self.max_bit_count}] "
                 f"as last byte is null [{data[len(data) - 1]}]"
             )
+
+        as_integer = int.from_bytes(data, "little")
+        len_value = get_bitlist_len(as_integer)
 
         if len_value > self.max_bit_count:
             raise DeserializationError(

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -31,6 +31,7 @@ def test_bitlist_deserialize_values(size, value, expected):
     foo = Bitlist(size)
     assert foo.deserialize(value) == expected
 
+
 # Sequences ending with 0x00 are not serialised bitlists
 # and should not be deserialised into bitlists.
 @pytest.mark.parametrize(
@@ -63,6 +64,7 @@ def test_bitlist_round_trip_no_sedes(size, value):
 @pytest.mark.parametrize(("sedes", "id"), ((Bitlist(64), "Bitlist64"),))
 def test_get_sedes_id(sedes, id):
     assert sedes.get_sedes_id() == id
+
 
 @pytest.mark.parametrize(("sedes1", "sedes2"), ((Bitlist(2), Bitlist(2)),))
 def test_eq(sedes1, sedes2):

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -2,6 +2,7 @@ import pytest
 
 from ssz import decode, encode
 from ssz.sedes import Bitlist, Bitvector, List, boolean
+from ssz.exceptions import DeserializationError, SerializationError
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,20 @@ def test_bitlist_deserialize_values(size, value, expected):
     foo = Bitlist(size)
     assert foo.deserialize(value) == expected
 
+# Sequences ending with 0x00 are not serialised bitlists and should not be deserialised into bitlists.
+@pytest.mark.parametrize(
+    "size, illegal_value",
+    (
+        (16, b"\x00"), # should not be accepted as last byte should be >= 1
+        (8, b"\xff\x00" ), # should not be accepted for the same reason
+        ),
+)
+
+#   Test that exception is raised when trying to deserialise illegal seq of bytes into bitlists.
+def test_bitlist_deserialize_illegal_values(size, illegal_value):
+    foo = Bitlist(size)
+    with pytest.raises(DeserializationError):
+        foo.deserialize(illegal_value)
 
 @pytest.mark.parametrize(
     "size, value",

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -2,7 +2,7 @@ import pytest
 
 from ssz import decode, encode
 from ssz.sedes import Bitlist, Bitvector, List, boolean
-from ssz.exceptions import DeserializationError, SerializationError
+from ssz.exceptions import DeserializationError
 
 
 @pytest.mark.parametrize(
@@ -31,20 +31,21 @@ def test_bitlist_deserialize_values(size, value, expected):
     foo = Bitlist(size)
     assert foo.deserialize(value) == expected
 
-# Sequences ending with 0x00 are not serialised bitlists and should not be deserialised into bitlists.
+# Sequences ending with 0x00 are not serialised bitlists
+# and should not be deserialised into bitlists.
 @pytest.mark.parametrize(
     "size, illegal_value",
     (
-        (16, b"\x00"), # should not be accepted as last byte should be >= 1
-        (8, b"\xff\x00" ), # should not be accepted for the same reason
-        ),
+        (16, b"\x00"),      # should not be accepted as last byte should be >= 1
+        (8, b"\xff\x00"),   # should not be accepted for the same reason
+    ),
 )
-
 #   Test that exception is raised when trying to deserialise illegal seq of bytes into bitlists.
 def test_bitlist_deserialize_illegal_values(size, illegal_value):
     foo = Bitlist(size)
     with pytest.raises(DeserializationError):
         foo.deserialize(illegal_value)
+
 
 @pytest.mark.parametrize(
     "size, value",
@@ -62,7 +63,6 @@ def test_bitlist_round_trip_no_sedes(size, value):
 @pytest.mark.parametrize(("sedes", "id"), ((Bitlist(64), "Bitlist64"),))
 def test_get_sedes_id(sedes, id):
     assert sedes.get_sedes_id() == id
-
 
 @pytest.mark.parametrize(("sedes1", "sedes2"), ((Bitlist(2), Bitlist(2)),))
 def test_eq(sedes1, sedes2):

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -1,8 +1,8 @@
 import pytest
 
 from ssz import decode, encode
-from ssz.sedes import Bitlist, Bitvector, List, boolean
 from ssz.exceptions import DeserializationError
+from ssz.sedes import Bitlist, Bitvector, List, boolean
 
 
 @pytest.mark.parametrize(
@@ -37,8 +37,9 @@ def test_bitlist_deserialize_values(size, value, expected):
 @pytest.mark.parametrize(
     "size, illegal_value",
     (
-        (16, b"\x00"),      # should not be accepted as last byte should be >= 1
-        (8, b"\xff\x00"),   # should not be accepted for the same reason
+        (16, b""),  # should not be accepted as length(input) should be >= 1
+        (16, b"\x00"),  # should not be accepted as last byte should be >= 1
+        (8, b"\xff\x00"),  # should not be accepted for the same reason
     ),
 )
 #   Test that exception is raised when trying to deserialise illegal seq of bytes into bitlists.
@@ -49,12 +50,7 @@ def test_bitlist_deserialize_illegal_values(size, illegal_value):
 
 
 @pytest.mark.parametrize(
-    "size, value",
-    (
-        # (16, tuple()),
-        (16, (True, False)),
-        (16, (True,) + (False,) * 15),
-    ),
+    "size, value", ((16, (True, False)), (16, (True,) + (False,) * 15),),
 )
 def test_bitlist_round_trip_no_sedes(size, value):
     foo = Bitlist(size)

--- a/tests/sedes/test_bitlist_serializer.py
+++ b/tests/sedes/test_bitlist_serializer.py
@@ -50,7 +50,7 @@ def test_bitlist_deserialize_illegal_values(size, illegal_value):
 
 
 @pytest.mark.parametrize(
-    "size, value", ((16, (True, False)), (16, (True,) + (False,) * 15),),
+    "size, value", ((16, (True, False)), (16, (True,) + (False,) * 15))
 )
 def test_bitlist_round_trip_no_sedes(size, value):
     foo = Bitlist(size)


### PR DESCRIPTION
## What was wrong?

A sequence of bytes ending with 0x00 cannot be a serialisation of a bitlist.
As a consequence it should not be possible to deserialise such sequence into a bitlist.
The current implementation allows that.

Issue #109 

## How the issue was uncovered?

This issue was uncovered as part of the formal verification of the Eth2.0 specs using Dafny: [issue 4](https://github.com/PegaSysEng/eth2.0-dafny/issues/4)

## How was it fixed?

Deserialise into bitlist code; add a test to check that the last byte is not null. If it is raise an exception.

Tests: two tests provided with illegal input for deserialising into biltists and check that the exception is actually raised.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.australiangeographic.com.au/wp-content/uploads/2018/06/z4bgsb94-1476852280.jpg)
