### PR TITLE
Fix homogeneous sequence boundary

### DIFF
--- a/ssz/sedes/basic.py
+++ b/ssz/sedes/basic.py
@@ -172,14 +172,6 @@ class ProperCompositeSedes(BaseProperCompositeSedes[TSerializable, TDeserialized
 class HomogeneousProperCompositeSedes(
     ProperCompositeSedes[TSerializable, TDeserialized]
 ):
-    def __init__(self, element_sedes: TSedes, max_length: int) -> None:
-        self.element_sedes = element_sedes
-        if max_length < 1:
-            raise ValueError(
-                f"(Maximum) length of homogenous composites must be at least 1, got {max_length}"
-            )
-        self.max_length = max_length
-
     def get_sedes_id(self) -> str:
         sedes_name = self.__class__.__name__
         return f"{sedes_name}({self.element_sedes.get_sedes_id()},{self.max_length})"

--- a/ssz/sedes/bitlist.py
+++ b/ssz/sedes/bitlist.py
@@ -20,7 +20,7 @@ BytesOrByteArray = Union[bytes, bytearray]
 class Bitlist(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
     def __init__(self, max_bit_count: int) -> None:
         if max_bit_count < 0:
-            raise TypeError("Max bit count cannot be negative")
+            raise ValueError(f"Max bit count cannot be negative, got {max_bit_count}")
         self.max_bit_count = max_bit_count
 
     #

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -18,8 +18,8 @@ BytesOrByteArray = Union[bytes, bytearray]
 
 class Bitvector(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
     def __init__(self, bit_count: int) -> None:
-        if bit_count <= 0:
-            raise TypeError("Bit count cannot be zero or negative")
+        if bit_count < 1:
+            raise ValueError(f"Bitvector must have a size of 1 or greater, got {bit_count}")
         self.bit_count = bit_count
 
     #

--- a/ssz/sedes/bitvector.py
+++ b/ssz/sedes/bitvector.py
@@ -19,7 +19,9 @@ BytesOrByteArray = Union[bytes, bytearray]
 class Bitvector(BitfieldCompositeSedes[BytesOrByteArray, bytes]):
     def __init__(self, bit_count: int) -> None:
         if bit_count < 1:
-            raise ValueError(f"Bitvector must have a size of 1 or greater, got {bit_count}")
+            raise ValueError(
+                f"Bitvector must have a size of 1 or greater, got {bit_count}"
+            )
         self.bit_count = bit_count
 
     #

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -32,7 +32,9 @@ class List(
 ):
     def __init__(self, element_sedes: TSedes, max_length: int) -> None:
         if max_length < 0:
-            raise ValueError(f"Lists must have a maximum length of 0 or greater, got {max_length}")
+            raise ValueError(
+                f"Lists must have a maximum length of 0 or greater, got {max_length}"
+            )
         self.element_sedes = element_sedes
         self.max_length = max_length
 

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -12,7 +12,7 @@ from ssz.constants import OFFSET_SIZE
 from ssz.exceptions import DeserializationError
 from ssz.hashable_list import HashableList
 from ssz.hashable_structure import BaseHashableStructure
-from ssz.sedes.base import BaseSedes
+from ssz.sedes.base import BaseSedes, TSedes
 from ssz.sedes.basic import BasicSedes, HomogeneousProperCompositeSedes
 from ssz.typing import CacheObj, TDeserialized, TSerializable
 from ssz.utils import (
@@ -30,6 +30,12 @@ TSedesPairs = Tuple[Tuple[BaseSedes[TSerializable, TDeserialized], TSerializable
 class List(
     HomogeneousProperCompositeSedes[Sequence[TSerializable], Tuple[TDeserialized, ...]]
 ):
+    def __init__(self, element_sedes: TSedes, max_length: int) -> None:
+        if max_length < 0:
+            raise ValueError(f"Lists must have a size of 0 or greater, got {max_length}")
+        self.element_sedes = element_sedes
+        self.max_length = max_length
+
     #
     # Size
     #

--- a/ssz/sedes/list.py
+++ b/ssz/sedes/list.py
@@ -32,7 +32,7 @@ class List(
 ):
     def __init__(self, element_sedes: TSedes, max_length: int) -> None:
         if max_length < 0:
-            raise ValueError(f"Lists must have a size of 0 or greater, got {max_length}")
+            raise ValueError(f"Lists must have a maximum length of 0 or greater, got {max_length}")
         self.element_sedes = element_sedes
         self.max_length = max_length
 

--- a/ssz/sedes/vector.py
+++ b/ssz/sedes/vector.py
@@ -28,9 +28,10 @@ class Vector(
     ]
 ):
     def __init__(self, element_sedes: TSedes, length: int) -> None:
-        if length <= 0:
+        if length < 1:
             raise ValueError(f"Vectors must have a size of 1 or greater, got {length}")
-        super().__init__(element_sedes, max_length=length)
+        self.element_sedes = element_sedes
+        self.max_length = length
 
     @property
     def length(self) -> int:

--- a/tests/sedes/test_bitvector_instantiation.py
+++ b/tests/sedes/test_bitvector_instantiation.py
@@ -4,6 +4,6 @@ from ssz.sedes import Bitvector
 
 
 def test_bitvector_instantiation_bound():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         bit_count = 0
         Bitvector(bit_count)

--- a/tests/sedes/test_composite_sedes.py
+++ b/tests/sedes/test_composite_sedes.py
@@ -7,7 +7,17 @@ import ssz
 from ssz.exceptions import DeserializationError
 from ssz.hashable_list import HashableList
 from ssz.hashable_vector import HashableVector
-from ssz.sedes import Bitlist, Bitvector, Container, List, UInt, Vector, bytes32, uint8, uint256
+from ssz.sedes import (
+    Bitlist,
+    Bitvector,
+    Container,
+    List,
+    UInt,
+    Vector,
+    bytes32,
+    uint8,
+    uint256,
+)
 
 
 @pytest.mark.parametrize(
@@ -175,7 +185,9 @@ def test_neq(sedes1, sedes2):
         (Vector, uint8, 0, False),
     ),
 )
-def test_homogeneous_sequence_length_boundary(sedes_type, element_type, length, is_valid):
+def test_homogeneous_sequence_length_boundary(
+    sedes_type, element_type, length, is_valid
+):
     if is_valid:
         sedes_type(element_type, length)
     else:

--- a/tests/sedes/test_composite_sedes.py
+++ b/tests/sedes/test_composite_sedes.py
@@ -7,7 +7,7 @@ import ssz
 from ssz.exceptions import DeserializationError
 from ssz.hashable_list import HashableList
 from ssz.hashable_vector import HashableVector
-from ssz.sedes import Container, List, UInt, Vector, bytes32, uint8, uint256
+from ssz.sedes import Bitlist, Bitvector, Container, List, UInt, Vector, bytes32, uint8, uint256
 
 
 @pytest.mark.parametrize(
@@ -164,3 +164,37 @@ def test_eq(sedes1, sedes2):
 def test_neq(sedes1, sedes2):
     assert sedes1 != sedes2
     assert hash(sedes1) != hash(sedes2)
+
+
+@pytest.mark.parametrize(
+    ("sedes_type", "element_type", "length", "is_valid"),
+    (
+        (List, uint8, 0, True),
+        (List, uint8, -1, False),
+        (Vector, uint8, 1, True),
+        (Vector, uint8, 0, False),
+    ),
+)
+def test_homogeneous_sequence_length_boundary(sedes_type, element_type, length, is_valid):
+    if is_valid:
+        sedes_type(element_type, length)
+    else:
+        with pytest.raises(ValueError):
+            sedes_type(element_type, length)
+
+
+@pytest.mark.parametrize(
+    ("sedes_type", "length", "is_valid"),
+    (
+        (Bitlist, 0, True),
+        (Bitlist, -1, False),
+        (Bitvector, 1, True),
+        (Bitvector, 0, False),
+    ),
+)
+def test_bitfield_length_boundary(sedes_type, length, is_valid):
+    if is_valid:
+        sedes_type(length)
+    else:
+        with pytest.raises(ValueError):
+            sedes_type(length)


### PR DESCRIPTION
## What was wrong?

Address issue #116 

## How was it fixed?

1. Remove `HomogeneousProperCompositeSedes.__init_()`
2. Update vector types' (`Vector` and `Bitvector`) `__init__()` with illegal condition `max_length < 1`.
3. Add list types' (`List` and `Bitlist`) `__init__()` with illegal condition `max_length < 0`.
4. Use `ValueError` for these exceptions.
5. Add tests: `test_homogeneous_sequence_length_boundary` and `test_bitfield_length_boundary`

#### Cute Animal Picture

![animal-5302420_640](https://user-images.githubusercontent.com/9263930/84981926-327d2980-b168-11ea-996d-c8cf43fce00f.jpg)


/cc @booleanfunction @saltiniroberto