### PR TITLE
Encode a byte list more naturally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,31 +39,31 @@ jobs:
   doctest:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: doctest
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: lint
   py36:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-core
   yaml:
     <<: *common
     docker:
-    - image: circleci/python:3.6
+    - image: cimg/python:3.6
       environment:
         TOXENV: yaml
   benchmark:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: benchmark
 workflows:

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -67,7 +67,7 @@ Released 2018-05-02
 - Fix equality of serializable objects - `#64 <https://github.com/ethereum/py-ssz/pull/64>`_
 - Add helpers to convert objects to and from a human readable representation -
   `#66 <https://github.com/ethereum/py-ssz/pull/66>`_
-- Cache hash tree root of serializable objects - `#68 https://github.com/ethereum/py-ssz/pull/68`_
+- Cache hash tree root of serializable objects - `#68 <https://github.com/ethereum/py-ssz/pull/68>`_
 
 
 v0.1.0-alpha.8

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ extras_require = {
         "mypy-extensions>=0.4.1,<1.0.0",
     ],
     "lint": ["flake8==3.7.8", "isort==4.3.21", "black==19.3b"],
-    "doc": ["Sphinx>=1.6.5,<2", "sphinx_rtd_theme>=0.1.9"],
+    "doc": [
+        "Sphinx>=1.6.5,<2",
+        "sphinx_rtd_theme>=0.1.9",
+        "Jinja2<3",
+        "MarkupSafe<2",
+    ],
     "dev": ["bumpversion>=0.5.3,<1", "wheel", "twine", "ipython", "pre-commit==1.18.3"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,16 @@ extras_require["dev"] = (
     + extras_require["doc"]
 )
 
+with open('./README.md') as readme:
+    long_description = readme.read()
+
 setup(
     name="ssz",
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version="0.2.4",
     description="""ssz: Python implementation of the Simple Serialization encoding and decoding""",
-    long_description_markdown_filename="README.md",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author="Jason Carver",
     author_email="ethcalibur+pip@gmail.com",
     url="https://github.com/ethereum/py-ssz",
@@ -41,7 +45,7 @@ setup(
         # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)
         "pyrsistent>=0.16.0,<0.17",
     ],
-    setup_requires=["setuptools-markdown"],
+    setup_requires=[],
     python_requires=">=3.6, <4",
     extras_require=extras_require,
     py_modules=["ssz"],

--- a/ssz/__init__.py
+++ b/ssz/__init__.py
@@ -12,6 +12,7 @@ from .sedes import (  # noqa: F401
     Bitvector,
     Boolean,
     Byte,
+    ByteList,
     ByteVector,
     Container,
     List,

--- a/ssz/hashable_structure.py
+++ b/ssz/hashable_structure.py
@@ -47,9 +47,10 @@ def update_element_in_chunk(
     replaces the element given by its index in the chunk with the given data.
 
     If the length of the element is zero or not a divisor of the chunk size, a `ValueError` is
-    raised. If the index is out of range, an `IndexError is raised.
+    raised. If the index is out of range, an `IndexError` is raised.
 
     Example:
+        >>> from ssz.hashable_structure import update_element_in_chunk
         >>> update_element_in_chunk(b"aabbcc", 1, b"xx")
         b'aaxxcc'
     """

--- a/ssz/sedes/__init__.py
+++ b/ssz/sedes/__init__.py
@@ -8,6 +8,7 @@ from .bitlist import Bitlist  # noqa: F401
 from .bitvector import Bitvector  # noqa: F401
 from .boolean import Boolean, boolean  # noqa: F401
 from .byte import Byte, byte  # noqa: F401
+from .byte_list import ByteList  # noqa: F401
 from .byte_vector import (  # noqa: F401
     ByteVector,
     bytes1,

--- a/ssz/sedes/byte_list.py
+++ b/ssz/sedes/byte_list.py
@@ -1,0 +1,53 @@
+from typing import Union
+
+from ssz.exceptions import DeserializationError, SerializationError
+from ssz.sedes.byte import byte
+from ssz.sedes.list import List
+from ssz.utils import merkleize, mix_in_length, pack_bytes
+
+BytesOrByteArray = Union[bytes, bytearray]
+
+
+class ByteList(List[BytesOrByteArray, bytes]):
+    """
+    Equivalent to `List(byte, size)` but more convenient & efficient.
+
+    When encoding a series of bytes, List(byte, ...) requires an awkward input
+    shaped like: ``(b'A', b'B', b'C')``. `ByteList` accepts a simple `bytes`
+    object like ``b'ABC'`` for encoding.
+    """
+
+    def __init__(self, max_length: int) -> None:
+        super().__init__(element_sedes=byte, max_length=max_length)
+
+    def serialize(self, value: BytesOrByteArray) -> bytes:
+        if len(value) > self.max_length:
+            raise SerializationError(
+                f"Cannot serialize length {len(value)} byte-string as ByteList{self.length}"
+            )
+
+        return value
+
+    def serialize_element_for_tree(self, index: int, byte_value: int) -> bytes:
+        if not 0 <= byte_value < 256:
+            raise SerializationError(
+                f"Cannot serialize byte as its value {byte_value} is invalid"
+            )
+
+        return bytes((byte_value,))
+
+    def deserialize(self, data: bytes) -> bytes:
+        if len(data) > self.max_length:
+            raise DeserializationError(
+                f"Cannot deserialize length {len(data)} data as ByteList{self.length}"
+            )
+        return data
+
+    def get_hash_tree_root(self, value: bytes) -> bytes:
+        serialized_value = self.serialize(value)
+        merkle_leaves = pack_bytes(serialized_value)
+        merkleized = merkleize(merkle_leaves, limit=self.chunk_count)
+        return mix_in_length(merkleized, len(value))
+
+    def get_sedes_id(self) -> str:
+        return f"{self.__class__.__name__}{self.length}"

--- a/tests/tree_hash/test_aliases_tree_hash.py
+++ b/tests/tree_hash/test_aliases_tree_hash.py
@@ -3,7 +3,7 @@ from hypothesis import strategies as st
 import pytest
 
 import ssz
-from ssz.sedes import ByteVector, Vector, byte, uint8
+from ssz.sedes import ByteList, ByteVector, List, Vector, byte, uint8
 
 
 @pytest.mark.parametrize(
@@ -21,3 +21,17 @@ def test_byte_vector(value):
         byte_sequence, Vector(byte, len(value))
     )
     assert ssz.get_hash_tree_root(value, ByteVector(len(value))) == expected_vector_root
+
+
+@given(st.binary(), st.booleans())
+def test_byte_list(value, same_size):
+    byte_sequence = tuple(bytes([byte_value]) for byte_value in value)
+
+    if same_size:
+        max_length = len(value)
+    else:
+        max_length = len(value) + 1
+
+    expected_vector_root = ssz.get_hash_tree_root(byte_sequence, List(byte, max_length))
+    calculated_vector_root = ssz.get_hash_tree_root(value, ByteList(max_length))
+    assert calculated_vector_root == expected_vector_root


### PR DESCRIPTION
## What was wrong?

Fix #118 

## How was it fixed?

Add a `ByteList` class that more efficiently encodes a variable-length series of bytes. It's also more convenient than sending in an iterable of single bytes. (since if you just send a `bytes` in python, it will yield each element as an `int` instead, which fails on a `List(Byte)`.

Generally, follow the same pattern as `ByteVector`. Add tests to make sure that `Byte(List)` is equivalent to `ByteList()`.

Skipped `.get_hash_tree_root_and_leaves()` implementation for now, for lack of context.

TODO
- [x] write test
- [x] build docs successfully
- [x] Move to another issue: `ByteList.get_hash_tree_root_and_leaves()`
- [x] Move to another issue: modernize the template, it's very old
- [x] Move to another issue: Upgrade black/isort and autoformat, including setup.py (started in another local branch already)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thesprucepets.com/thmb/JS85cLYj-KJHWl73ZlLauYQ5Bn4=/735x0/dog-bite-147942153-resized-56a26ac33df78cf772756258.jpg)