### PR TITLE
Add release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-all:
 	tox
 
 build-docs:
-	sphinx-apidoc -o docs/ . setup.py "*conftest*"
+	sphinx-apidoc -o docs/ . setup.py "*conftest*" "tests/"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint:
 	tox -elint
 
 lint-roll:
+	black ssz tests scripts setup.py
 	isort --recursive ssz tests
 	$(MAKE) lint
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,42 +3,40 @@ Release Notes
 
 .. towncrier release notes start
 
-v0.1.0-alpha.0
+v0.2.4
 --------------
 
-- Launched repository, claimed names for pip, RTD, github, etc
+Released 2020-03-24
+
+- Update `pyrsistent` dependency.
 
 
-v0.1.0-alpha.1
+v0.1.0-alpha.8
 --------------
 
-Released 2018-02-05
+Released 2018-05-05
 
-- Implements January pre-release spec
+- Less strict class relationship requirement for equality of serializables -
+  `#71 <https://github.com/ethereum/py-ssz/pull/71>`_
 
 
-v0.1.0-alpha.2
+v0.1.0-alpha.7
 --------------
 
-Released 2018-02-05
+Released 2018-05-02
 
-- Add zero padding to tree hash - `#35 <https://github.com/ethereum/py-ssz/pull/35>`_
+- Fix equality of serializable objects - `#64 <https://github.com/ethereum/py-ssz/pull/64>`_
+- Add helpers to convert objects to and from a human readable representation -
+  `#66 <https://github.com/ethereum/py-ssz/pull/66>`_
+- Cache hash tree root of serializable objects - `#68 <https://github.com/ethereum/py-ssz/pull/68>`_
 
 
-v0.1.0-alpha.3
+v0.1.0-alpha.6
 --------------
 
-Released 2018-04-04
+Released 2018-04-23
 
-- Implement spec version 0.5.0
-
-
-v0.1.0-alpha.4
---------------
-
-Released 2018-04-09
-
-- Fix bug in serializable class - `#56 <https://github.com/ethereum/py-ssz/pull/56>`_
+No changes
 
 
 v0.1.0-alpha.5
@@ -53,37 +51,40 @@ Released 2018-04-23
   `#57 <https://github.com/ethereum/py-ssz/pull/57>`_
 
 
-v0.1.0-alpha.6
+v0.1.0-alpha.4
 --------------
 
-Released 2018-04-23
+Released 2018-04-09
 
-No changes
+- Fix bug in serializable class - `#56 <https://github.com/ethereum/py-ssz/pull/56>`_
 
 
-v0.1.0-alpha.7
+v0.1.0-alpha.3
 --------------
 
-Released 2018-05-02
+Released 2018-04-04
 
-- Fix equality of serializable objects - `#64 <https://github.com/ethereum/py-ssz/pull/64>`_
-- Add helpers to convert objects to and from a human readable representation -
-  `#66 <https://github.com/ethereum/py-ssz/pull/66>`_
-- Cache hash tree root of serializable objects - `#68 <https://github.com/ethereum/py-ssz/pull/68>`_
+- Implement spec version 0.5.0
 
 
-v0.1.0-alpha.8
+v0.1.0-alpha.2
 --------------
 
-Released 2018-05-05
+Released 2018-02-05
 
-- Less strict class relationship requirement for equality of serializables -
-  `#71 <https://github.com/ethereum/py-ssz/pull/71>`_
+- Add zero padding to tree hash - `#35 <https://github.com/ethereum/py-ssz/pull/35>`_
 
 
-v0.2.4
+v0.1.0-alpha.1
 --------------
 
-Released 2020-03-24
+Released 2018-02-05
 
-- Update `pyrsistent` dependency.
+- Implements January pre-release spec
+
+
+v0.1.0-alpha.0
+--------------
+
+- Launched repository, claimed names for pip, RTD, github, etc
+

--- a/newsfragments/109.bugfix.rst
+++ b/newsfragments/109.bugfix.rst
@@ -1,0 +1,1 @@
+Reject empty bytes at the end of a bitlist as invalid

--- a/newsfragments/111.bugfix.rst
+++ b/newsfragments/111.bugfix.rst
@@ -1,0 +1,1 @@
+Reject vectors and bitvectors of length 0 as invalid, as defined in the spec.

--- a/newsfragments/116.bugfix.rst
+++ b/newsfragments/116.bugfix.rst
@@ -1,0 +1,1 @@
+Enforce that vector types must have a maximum length of 1 or more, and lists may have a 0 max length

--- a/newsfragments/118.feature.rst
+++ b/newsfragments/118.feature.rst
@@ -1,0 +1,3 @@
+Add a :class:`~ssz.sedes.byte_list.ByteList` sedes that is more convenient and more performant. With
+ByteList, the caller can decode a :class:`bytes` object, rather than passing in a list of
+single-byte elements.

--- a/newsfragments/120.internal.rst
+++ b/newsfragments/120.internal.rst
@@ -1,0 +1,1 @@
+Upgrade black to a stable version, and pass newest style checks

--- a/newsfragments/121.internal.rst
+++ b/newsfragments/121.internal.rst
@@ -1,0 +1,2 @@
+Use the latest project template, which gives many developer-focused benefits: in making release
+notes, releasing new versions, etc.

--- a/newsfragments/124.doc.rst
+++ b/newsfragments/124.doc.rst
@@ -1,0 +1,1 @@
+Sort release notes with most recent on top

--- a/newsfragments/124.misc.rst
+++ b/newsfragments/124.misc.rst
@@ -1,0 +1,3 @@
+Run black autoformat, as part of ``make lint-roll``. Added some tests to check length validation of
+:class:`~ssz.sedes.byte_list.ByteList` and :class:`~ssz.sedes.byte_vector.ByteVector`. When
+generating website docs from docstrings, skip tests.

--- a/tests/sedes/test_composite_sedes.py
+++ b/tests/sedes/test_composite_sedes.py
@@ -10,6 +10,8 @@ from ssz.hashable_vector import HashableVector
 from ssz.sedes import (
     Bitlist,
     Bitvector,
+    ByteList,
+    ByteVector,
     Container,
     List,
     UInt,
@@ -193,6 +195,23 @@ def test_homogeneous_sequence_length_boundary(
     else:
         with pytest.raises(ValueError):
             sedes_type(element_type, length)
+
+
+@pytest.mark.parametrize(
+    ("sedes_type", "length", "is_valid"),
+    (
+        (ByteList, 0, True),
+        (ByteList, -1, False),
+        (ByteVector, 1, True),
+        (ByteVector, 0, False),
+    ),
+)
+def test_byte_sequence_length_boundary(sedes_type, length, is_valid):
+    if is_valid:
+        sedes_type(length)
+    else:
+        with pytest.raises(ValueError):
+            sedes_type(length)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was wrong?

There weren't any release notes added for the last few PRs

## How was it fixed?

- Added them as best as I could understand
- Reversed the sorting order of the release notes, so most recent is up top
- Added some bonus tests that I noticed would improve the new `ByteList` (and older `ByteVector`) sedes
- Don't auto-generate docs for tests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-ssz/blob/master/newsfragments/README.md)

[//]: # (See: https://ssz.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-ssz/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/JL6PaZt6BNs/maxresdefault.jpg)
