### PR TITLE
Compile release notes for v0.3.0

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,50 @@ Release Notes
 
 .. towncrier release notes start
 
+py-ssz v0.3.0 (2022-08-19)
+--------------------------
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- Dropping official support for Python 3.6 (although it still worked as of the last test run). (`#125 <https://github.com/ethereum/py-ssz/issues/125>`__)
+
+
+Features
+~~~~~~~~
+
+- Add a :class:`~ssz.sedes.byte_list.ByteList` sedes that is more convenient and more performant. With
+  ByteList, the caller can decode a :class:`bytes` object, rather than passing in a list of
+  single-byte elements. (`#118 <https://github.com/ethereum/py-ssz/issues/118>`__)
+
+
+Bugfixes
+~~~~~~~~
+
+- Reject empty bytes at the end of a bitlist as invalid (`#109 <https://github.com/ethereum/py-ssz/issues/109>`__)
+- Reject vectors and bitvectors of length 0 as invalid, as defined in the spec. (`#111 <https://github.com/ethereum/py-ssz/issues/111>`__)
+- Enforce that vector types must have a maximum length of 1 or more, and lists may have a 0 max length (`#116 <https://github.com/ethereum/py-ssz/issues/116>`__)
+
+
+Improved Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Sort release notes with most recent on top (`#124 <https://github.com/ethereum/py-ssz/issues/124>`__)
+
+
+Internal Changes - for py-ssz Contributors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Upgrade black to a stable version, and pass newest style checks (`#120 <https://github.com/ethereum/py-ssz/issues/120>`__)
+- Use the latest project template, which gives many developer-focused benefits: in making release
+  notes, releasing new versions, etc. (`#121 <https://github.com/ethereum/py-ssz/issues/121>`__)
+- Miscellaneous changes (`#124 <https://github.com/ethereum/py-ssz/issues/124>`__):
+
+  - Run black autoformat, as part of ``make lint-roll``
+  - Added some tests to check length validation of :class:`~ssz.sedes.byte_list.ByteList` and :class:`~ssz.sedes.byte_vector.ByteVector`
+  - When generating website docs from docstrings, skip tests
+
+
 v0.2.4
 --------------
 

--- a/docs/ssz.cache.rst
+++ b/docs/ssz.cache.rst
@@ -1,0 +1,30 @@
+ssz.cache package
+=================
+
+Submodules
+----------
+
+ssz.cache.cache module
+----------------------
+
+.. automodule:: ssz.cache.cache
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.cache.utils module
+----------------------
+
+.. automodule:: ssz.cache.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ssz.cache
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/ssz.rst
+++ b/docs/ssz.rst
@@ -1,0 +1,127 @@
+ssz package
+===========
+
+Subpackages
+-----------
+
+.. toctree::
+
+    ssz.cache
+    ssz.sedes
+    ssz.tools
+
+Submodules
+----------
+
+ssz.abc module
+--------------
+
+.. automodule:: ssz.abc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.codec module
+----------------
+
+.. automodule:: ssz.codec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.constants module
+--------------------
+
+.. automodule:: ssz.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.exceptions module
+---------------------
+
+.. automodule:: ssz.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hash module
+---------------
+
+.. automodule:: ssz.hash
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hash\_tree module
+---------------------
+
+.. automodule:: ssz.hash_tree
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hashable\_container module
+------------------------------
+
+.. automodule:: ssz.hashable_container
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hashable\_list module
+-------------------------
+
+.. automodule:: ssz.hashable_list
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hashable\_structure module
+------------------------------
+
+.. automodule:: ssz.hashable_structure
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.hashable\_vector module
+---------------------------
+
+.. automodule:: ssz.hashable_vector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.tree\_hash module
+---------------------
+
+.. automodule:: ssz.tree_hash
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.typing module
+-----------------
+
+.. automodule:: ssz.typing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.utils module
+----------------
+
+.. automodule:: ssz.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ssz
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/ssz.sedes.rst
+++ b/docs/ssz.sedes.rst
@@ -1,0 +1,126 @@
+ssz.sedes package
+=================
+
+Submodules
+----------
+
+ssz.sedes.base module
+---------------------
+
+.. automodule:: ssz.sedes.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.basic module
+----------------------
+
+.. automodule:: ssz.sedes.basic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.bitlist module
+------------------------
+
+.. automodule:: ssz.sedes.bitlist
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.bitvector module
+--------------------------
+
+.. automodule:: ssz.sedes.bitvector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.boolean module
+------------------------
+
+.. automodule:: ssz.sedes.boolean
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.byte module
+---------------------
+
+.. automodule:: ssz.sedes.byte
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.byte\_list module
+---------------------------
+
+.. automodule:: ssz.sedes.byte_list
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.byte\_vector module
+-----------------------------
+
+.. automodule:: ssz.sedes.byte_vector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.container module
+--------------------------
+
+.. automodule:: ssz.sedes.container
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.list module
+---------------------
+
+.. automodule:: ssz.sedes.list
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.serializable module
+-----------------------------
+
+.. automodule:: ssz.sedes.serializable
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.signed\_serializable module
+-------------------------------------
+
+.. automodule:: ssz.sedes.signed_serializable
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.uint module
+---------------------
+
+.. automodule:: ssz.sedes.uint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.sedes.vector module
+-----------------------
+
+.. automodule:: ssz.sedes.vector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ssz.sedes
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/ssz.tools.rst
+++ b/docs/ssz.tools.rst
@@ -1,0 +1,38 @@
+ssz.tools package
+=================
+
+Submodules
+----------
+
+ssz.tools.codec module
+----------------------
+
+.. automodule:: ssz.tools.codec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.tools.dump module
+---------------------
+
+.. automodule:: ssz.tools.dump
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ssz.tools.parse module
+----------------------
+
+.. automodule:: ssz.tools.parse
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ssz.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/newsfragments/109.bugfix.rst
+++ b/newsfragments/109.bugfix.rst
@@ -1,1 +1,0 @@
-Reject empty bytes at the end of a bitlist as invalid

--- a/newsfragments/111.bugfix.rst
+++ b/newsfragments/111.bugfix.rst
@@ -1,1 +1,0 @@
-Reject vectors and bitvectors of length 0 as invalid, as defined in the spec.

--- a/newsfragments/116.bugfix.rst
+++ b/newsfragments/116.bugfix.rst
@@ -1,1 +1,0 @@
-Enforce that vector types must have a maximum length of 1 or more, and lists may have a 0 max length

--- a/newsfragments/118.feature.rst
+++ b/newsfragments/118.feature.rst
@@ -1,3 +1,0 @@
-Add a :class:`~ssz.sedes.byte_list.ByteList` sedes that is more convenient and more performant. With
-ByteList, the caller can decode a :class:`bytes` object, rather than passing in a list of
-single-byte elements.

--- a/newsfragments/120.internal.rst
+++ b/newsfragments/120.internal.rst
@@ -1,1 +1,0 @@
-Upgrade black to a stable version, and pass newest style checks

--- a/newsfragments/121.internal.rst
+++ b/newsfragments/121.internal.rst
@@ -1,2 +1,0 @@
-Use the latest project template, which gives many developer-focused benefits: in making release
-notes, releasing new versions, etc.

--- a/newsfragments/124.doc.rst
+++ b/newsfragments/124.doc.rst
@@ -1,1 +1,0 @@
-Sort release notes with most recent on top

--- a/newsfragments/124.misc.rst
+++ b/newsfragments/124.misc.rst
@@ -1,3 +1,0 @@
-Run black autoformat, as part of ``make lint-roll``. Added some tests to check length validation of
-:class:`~ssz.sedes.byte_list.ByteList` and :class:`~ssz.sedes.byte_vector.ByteVector`. When
-generating website docs from docstrings, skip tests.

--- a/newsfragments/125.breaking.rst
+++ b/newsfragments/125.breaking.rst
@@ -1,1 +1,0 @@
-Dropping official support for Python 3.6 (although it still worked as of the last test run).

--- a/ssz/sedes/byte_list.py
+++ b/ssz/sedes/byte_list.py
@@ -13,8 +13,8 @@ class ByteList(List[BytesOrByteArray, bytes]):
     Equivalent to `List(byte, size)` but more convenient & efficient.
 
     When encoding a series of bytes, List(byte, ...) requires an awkward input
-    shaped like: ``(b'A', b'B', b'C')``. `ByteList` accepts a simple `bytes`
-    object like ``b'ABC'`` for encoding.
+    shaped like: ``(b'A', b'B', b'C')``. `ByteList` accepts a simple
+    :class:`bytes` object like ``b'ABC'`` for encoding.
     """
 
     def __init__(self, max_length: int) -> None:


### PR DESCRIPTION
Ran `make notes bump=minor` (minor, because of a breaking change in a v0 library).

Also:
- Manually expanded the miscellaneous changes into internal
- Fixed a docstring in ByteList so that `bytes` is linked correctly
- Pushed Breaking Changes to the top, it should be the most important thing to notice as a skimming reader.