### PR TITLE
bump eth-utils requirement to >=2

### DIFF
--- a/newsfragments/132.internal.rst
+++ b/newsfragments/132.internal.rst
@@ -1,0 +1,1 @@
+bump eth-utils requirement version to >=2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     url="https://github.com/ethereum/py-ssz",
     include_package_data=True,
     install_requires=[
-        "eth-utils>=1,<2",
+        "eth-utils>=2",
         "lru-dict>=1.1.6",
         # When updating to a newer version of pyrsistent, please check that the interface
         # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)


### PR DESCRIPTION
### What was wrong?

`eth-utils` requirement version was pinned <2
Closes #127 

### How was it fixed?

Bumped to >=2

### Todo:
- [x] Clean up commit history

- [x] Add entry to the [release notes](https://github.com/ethereum/py-ssz/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/5199899/233188615-f4475e70-b46c-422e-9961-c63bd41d0810.png)
