### PR TITLE
add build.os to rtd config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,13 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip

--- a/newsfragments/133.internal.rst
+++ b/newsfragments/133.internal.rst
@@ -1,0 +1,1 @@
+Add ``build.os`` config to readthedocs.yml


### PR DESCRIPTION
### What was wrong?

ReadTheDocs will soon require `build.os` config

### How was it fixed?

Added to readthedocs.yml

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-ssz/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-ssz/assets/5199899/742e2bf1-7a76-41b2-b118-3c71ceb600e2)