### PR TITLE
remove pyrsistent upper pin

### DIFF
--- a/newsfragments/140.internal.rst
+++ b/newsfragments/140.internal.rst
@@ -1,0 +1,1 @@
+Bump to ``pyrsistent>=0.18.0`` and remove upper pin

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
         "lru-dict>=1.1.6",
-        # When updating to a newer version of pyrsistent, please check that the interface
-        # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)
-        "pyrsistent>=0.18.0",
+        "pyrsistent>=0.16.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "lru-dict>=1.1.6",
         # When updating to a newer version of pyrsistent, please check that the interface
         # `transform` expects has not changed (see https://github.com/tobgu/pyrsistent/issues/180)
-        "pyrsistent>=0.16.0,<0.17",
+        "pyrsistent>=0.18.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/tests/core/misc/test_pyrsistent.py
+++ b/tests/core/misc/test_pyrsistent.py
@@ -1,0 +1,15 @@
+import inspect
+
+from pyrsistent._transformations import (
+    transform,
+)
+
+# transform is an internal function, so techinally could be changed without a breaking
+# release. It's been stable for years, so we're testing it here to ensure it doesn't
+# change rather than continuing to use an upper pin in dependencies.
+# https://github.com/tobgu/pyrsistent/issues/180
+
+
+def test_transform():
+    expected = "def transform(structure, transformations):\n    r = structure\n    for path, command in _chunks(transformations, 2):\n        r = _do_to_path(r, path, command)\n    return r"  # noqa: E501
+    assert inspect.getsource(transform).strip() == expected


### PR DESCRIPTION
### What was wrong?

`pyrsistent` dep is has an upper pin that only officially supports up to py38

Related to Issue #140
Closes #140

### How was it fixed?

Remove upper pin on `pyrsistent` dep.

The upper pin exists because we make use of an internal `transform` function, but it hasn't changed for years and the maintainer doesn't expect it to - https://github.com/tobgu/pyrsistent/issues/180

We already have a test for our usage of `transform` in `test_hashable_structures`, so I've added a test to make sure the source code hasn't changed.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-ssz/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/d052bd71-4d20-45d5-842d-cf1772567389)
