### PR TITLE
py13 windows wheel build is failing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,5 +83,5 @@ commands=
     bash.exe -c "rm -rf build dist"
     python -m build
     bash.exe -c 'python -m pip install --upgrade "$(ls dist/ssz-*-py3-none-any.whl)" --progress-bar off'
-    python -c "import ssz"
+    python -X faulthandler -c "import ssz"
 skip_install=true


### PR DESCRIPTION
### What was wrong?

CI for for the py313 windows wheel is failing.

### How was it fixed?

Can't be fixed here, looks like it's an `lru-dict` issue - https://github.com/amitdev/lru-dict/issues/72

Once they push py313 support, this should resolve.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-ssz/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/249d8730-1418-41bc-bffe-ddc5ed35c2cf)
